### PR TITLE
Remove ib-sriov-cni from supported CNIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ For a Kubernetes deployment, each SR-IOV capable worker node should have:
 - [Multus CNI](https://github.com/intel/multus-cni) `v3.4.1` or newer deployed and configured
 - Per fabric SR-IOV supporting CNI deployed
     - __Ethernet__: [SR-IOV CNI](https://github.com/intel/sriov-cni)
-    - __Infiniband__: [Infiniband SR-IOV CNI](https://github.com/Mellanox/ib-sriov-cni)
 
 > __*Note:*__: Kubernetes version 1.16 or newer is required for deploying as daemonset
 


### PR DESCRIPTION
Due to CNI / kernel behaviour it is not possible to
support ib-sriov-cni in a chain to enable RDMA
network namespace isolation.

Reasons being:
1. ib-sriov-cni rebinds VF to set MAC causing RDMA device to be
   recreated (during CmdAdd and CmdDel)
2. Kernel recreates all associated RDMA resources (e.g IPoIB) once
   RDMA device is moved to a different namespace causing possible
   issues when restoring netdevice configurations

Once the issues are solved, we can add it back to supporting CNIs