### PR TITLE
Travis should run make test instead of make lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - go get -u github.com/mattn/goveralls
 
 script:
-  - make lint
+  - make test
   - make test-coverage
   - goveralls -coverprofile=rdma-cni.cover -service=travis-ci
   - make image


### PR DESCRIPTION
Make lint will not trigger go test execution.
In addition, in the future additional tags may be added to be executed
by make test.