### PR TITLE
Lock OS thread for main goroutine

### DIFF
--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/Mellanox/rdma-cni/pkg/cache"
 	"github.com/Mellanox/rdma-cni/pkg/rdma"
@@ -24,6 +25,14 @@ import (
 var (
 	logLevel = zerolog.InfoLevel
 )
+
+//nolint:gochecknoinits
+func init() {
+	// this ensures that main runs only on main thread (thread group leader).
+	// since namespace ops (unshare, setns) are done for a single thread, we
+	// must ensure that the goroutine does not jump from OS thread to thread
+	runtime.LockOSThread()
+}
 
 type NsManager interface {
 	GetNS(string) (ns.NetNS, error)


### PR DESCRIPTION
In short if the main code performs network operations assuming
they are done in the default namespace this may not always be the case.
locking the goroutine to the current OS thread ensures that any
operation that is performed, is performed in the default namespace.

While i have not encounterated a case where an operation ran
in the wrong namespace as all operations that are performed in a
namespace other than the default one are performed after locking the OS
thread to the goroutine (and released after).

However, i see the same pattern is done in other CNI's...