### PR TITLE
Update sriov device plugin resource configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ data:
         {
            "resourcePrefix": "mellanox.com",
            "resourceName": "sriov_rdma",
-           "isRdma": true,
            "selectors": {
+               "isRdma": true,
                "vendors": ["15b3"],
                "pfNames": ["enp4s0f0"]
            }

--- a/examples/sriov_dp_rdma_resource.yaml
+++ b/examples/sriov_dp_rdma_resource.yaml
@@ -10,8 +10,8 @@ data:
         {
            "resourcePrefix": "mellanox.com",
            "resourceName": "sriov_rdma",
-           "isRdma": true,
            "selectors": {
+               "isRdma": true,
                "vendors": ["15b3"],
                "pfNames": ["enp4s0f0"]
            }


### PR DESCRIPTION
sriov-network device plugin has moved to selectors per device type.
Update relevant examples in project.