### PR TITLE
Add clean modcache in clean step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ image: | $(BASE) ; $(info Building Docker image...)  @ ## Build conatiner image
 
 .PHONY: clean
 clean: ; $(info  Cleaning...)	 @ ## Cleanup everything
+	@$(GO) clean -modcache
 	@rm -rf $(GOPATH)
 	@rm -rf $(BUILDDIR)
 	@rm -rf  test


### PR DESCRIPTION
The files generated by gomod are readonly which
prevents them from being deleted by the normal `rm` command.

use go's builtin clean -modcache command for cleaning the cloned
repos.