### PR TITLE
Adding 'rdmaDeviceName' in CNI arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ For a Kubernetes deployment, each SR-IOV capable worker node should have:
 ```
 > __*Note:*__ "args" keyword is optional.
 
+### RDMADeviceName (optional)
+Optional `rdmaDeviceName` (under `args.cni`) allow users to set custom RDMA device name. Upon `cmdDel` original RDMA device name will be restored.
+
+```json
+{
+  "cniVersion": "0.3.1",
+  "type": "rdma",
+  "args": {
+    "cni": {
+      "rdmaDeviceName": "custom-name",
+      "debug": true
+    }
+  }
+}
+```
+> __*Note:*__ `rdmaDeviceName` is optional
+
 # Deployment
 
 ## System configuration

--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -165,8 +165,11 @@ func (plugin *rdmaCniPlugin) moveRdmaDevFromNs(rdmaDev, nsPath string) error {
 
 func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	log.Info().Msgf("RDMA-CNI: cmdAdd")
-	var err error
-	var conf *rdmatypes.RdmaNetConf
+	var (
+		err            error
+		conf           *rdmatypes.RdmaNetConf
+		currentRdmaDev string
+	)
 	conf, err = plugin.parseConf(args.StdinData, args.Args)
 	if err != nil {
 		return err
@@ -210,6 +213,16 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return fmt.Errorf("failed to get RDMA device for device ID %s: %w", conf.DeviceID, err)
 	}
+	currentRdmaDev = rdmaDev
+
+	// user can specify a custom RDMA device name through the CNI args
+	err = plugin.setRdmaDevName(rdmaDev, conf.Args.CNI.RDMADeviceName)
+	if err != nil {
+		return fmt.Errorf("failed to set RDMA device %s name: %w", rdmaDev, err)
+	}
+	if conf.Args.CNI.RDMADeviceName != "" {
+		rdmaDev = conf.Args.CNI.RDMADeviceName
+	}
 
 	err = plugin.moveRdmaDevToNs(rdmaDev, args.Netns)
 	if err != nil {
@@ -219,8 +232,8 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	// Save RDMA state
 	state := rdmatypes.NewRdmaNetState()
 	state.DeviceID = conf.DeviceID
-	state.SandboxRdmaDevName = rdmaDev
-	state.ContainerRdmaDevName = rdmaDev
+	state.SandboxRdmaDevName = currentRdmaDev
+	state.ContainerRdmaDevName = currentRdmaDev
 	pRef := plugin.stateCache.GetStateRef(conf.Name, args.ContainerID, args.IfName)
 	err = plugin.stateCache.Save(pRef, &state)
 	if err != nil {
@@ -268,6 +281,8 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 	}
 
 	// Move RDMA device to default namespace
+	// upon RDMA device restore, the RDMA device name will be set to its original name
+	// and not the custom name specified by the user in the CNI args
 	err = plugin.moveRdmaDevFromNs(rdmaState.ContainerRdmaDevName, args.Netns)
 	if err != nil {
 		return fmt.Errorf(
@@ -303,6 +318,16 @@ func (plugin *rdmaCniPlugin) getRDMADevice(deviceID string) (string, error) {
 	}
 
 	return rdmaDevs[0], nil
+}
+
+// setRdmaDevName sets the RDMA device name according to the user's CNI args
+func (plugin *rdmaCniPlugin) setRdmaDevName(rdmaDev string, rdmaDevName string) error {
+	log.Info().Msgf("setting RDMA device %s name to %s", rdmaDev, rdmaDevName)
+	err := plugin.rdmaManager.SetRdmaDevName(rdmaDev, rdmaDevName)
+	if err != nil {
+		return fmt.Errorf("failed to set RDMA device %s name: %w", rdmaDev, err)
+	}
+	return nil
 }
 
 func setupLogging() {

--- a/cmd/rdma/main_test.go
+++ b/cmd/rdma/main_test.go
@@ -35,7 +35,7 @@ func generateNetConfCmdDel(netName string) rdmaTypes.RdmaNetConf {
 	}
 }
 
-func generateNetConfCmdAdd(netName, cIfname, deviceID string) rdmaTypes.RdmaNetConf {
+func generateNetConfCmdAdd(netName, cIfname, deviceID string, rdmaDevName string) rdmaTypes.RdmaNetConf {
 	prevResult := current.Result{
 		CNIVersion: "0.4.0",
 		Interfaces: []*current.Interface{{
@@ -63,6 +63,7 @@ func generateNetConfCmdAdd(netName, cIfname, deviceID string) rdmaTypes.RdmaNetC
 			PrevResult:    nil,
 		},
 		DeviceID: deviceID,
+		Args:     rdmaTypes.CNIArgs{CNI: rdmaTypes.RdmaCNIArgs{RDMADeviceName: rdmaDevName}},
 	}
 }
 
@@ -230,10 +231,11 @@ var _ = Describe("Main", func() {
 				cid := "a1b2c3d4e5f6"
 				cnsPath := "/proc/12444/ns/net"
 				cns, _ := dummyNsMgr.GetNS(cnsPath)
-				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev)
+				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev, "")
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
 				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
 				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{rdmaDev}, nil)
+				rdmaMgrMock.On("SetRdmaDevName", rdmaDev, netconf.Args.CNI.RDMADeviceName).Return(nil)
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
 				expectedState := generateRdmaNetState(pciDev, rdmaDev, rdmaDev)
@@ -251,13 +253,39 @@ var _ = Describe("Main", func() {
 				cid := "a6b5c4d3e2f1"
 				cnsPath := "/proc/11142/ns/net"
 				cns, _ := dummyNsMgr.GetNS(cnsPath)
-				netconf := generateNetConfCmdAdd(netName, cIfname, auxDev)
+				netconf := generateNetConfCmdAdd(netName, cIfname, auxDev, "")
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
 				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
 				rdmaMgrMock.On("GetRdmaDevsForAuxDev", auxDev).Return([]string{rdmaDev}, nil)
+				rdmaMgrMock.On("SetRdmaDevName", rdmaDev, netconf.Args.CNI.RDMADeviceName).Return(nil)
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
 				expectedState := generateRdmaNetState(auxDev, rdmaDev, rdmaDev)
+				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
+				err := plugin.CmdAdd(&args)
+				Expect(err).ToNot(HaveOccurred())
+				rdmaMgrMock.AssertExpectations(t)
+				stateCacheMock.AssertExpectations(t)
+			})
+			It("Should succeed and move Rdma device associated with provided PCI DeviceID to Namespace with custom RDMA device name", func() {
+				pciDev := "0000:04:00.5"
+				netName := "rdma-net"
+				rdmaDev := "mlx5_4"
+				currentRdmaDev := "mlx5_4"
+				customRdmaDev := "custom-rdma"
+				cIfname := "net1"
+				cid := "a1b2c3d4e5f6"
+				cnsPath := "/proc/12444/ns/net"
+				cns, _ := dummyNsMgr.GetNS(cnsPath)
+				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev, customRdmaDev)
+				args := generateArgs(cnsPath, cid, cIfname, &netconf)
+				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
+				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{rdmaDev}, nil)
+				rdmaMgrMock.On("SetRdmaDevName", rdmaDev, netconf.Args.CNI.RDMADeviceName).Return(nil)
+				rdmaDev = netconf.Args.CNI.RDMADeviceName
+				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
+				expectedState := generateRdmaNetState(pciDev, currentRdmaDev, currentRdmaDev)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
 				err := plugin.CmdAdd(&args)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/rdma/mocks/RdmaBasicOps.go
+++ b/pkg/rdma/mocks/RdmaBasicOps.go
@@ -204,6 +204,63 @@ func (_c *MockBasicOps_RdmaLinkByName_Call) RunAndReturn(run func(name string) (
 	return _c
 }
 
+// RdmaLinkSetName provides a mock function for the type MockBasicOps
+func (_mock *MockBasicOps) RdmaLinkSetName(link *netlink.RdmaLink, name string) error {
+	ret := _mock.Called(link, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RdmaLinkSetName")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*netlink.RdmaLink, string) error); ok {
+		r0 = returnFunc(link, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBasicOps_RdmaLinkSetName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RdmaLinkSetName'
+type MockBasicOps_RdmaLinkSetName_Call struct {
+	*mock.Call
+}
+
+// RdmaLinkSetName is a helper method to define mock.On call
+//   - link *netlink.RdmaLink
+//   - name string
+func (_e *MockBasicOps_Expecter) RdmaLinkSetName(link interface{}, name interface{}) *MockBasicOps_RdmaLinkSetName_Call {
+	return &MockBasicOps_RdmaLinkSetName_Call{Call: _e.mock.On("RdmaLinkSetName", link, name)}
+}
+
+func (_c *MockBasicOps_RdmaLinkSetName_Call) Run(run func(link *netlink.RdmaLink, name string)) *MockBasicOps_RdmaLinkSetName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *netlink.RdmaLink
+		if args[0] != nil {
+			arg0 = args[0].(*netlink.RdmaLink)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBasicOps_RdmaLinkSetName_Call) Return(err error) *MockBasicOps_RdmaLinkSetName_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBasicOps_RdmaLinkSetName_Call) RunAndReturn(run func(link *netlink.RdmaLink, name string) error) *MockBasicOps_RdmaLinkSetName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RdmaLinkSetNsFd provides a mock function for the type MockBasicOps
 func (_mock *MockBasicOps) RdmaLinkSetNsFd(link *netlink.RdmaLink, fd uint32) error {
 	ret := _mock.Called(link, fd)

--- a/pkg/rdma/mocks/RdmaManager.go
+++ b/pkg/rdma/mocks/RdmaManager.go
@@ -252,6 +252,63 @@ func (_c *MockManager_MoveRdmaDevToNs_Call) RunAndReturn(run func(rdmaDev string
 	return _c
 }
 
+// SetRdmaDevName provides a mock function for the type MockManager
+func (_mock *MockManager) SetRdmaDevName(rdmaDev string, name string) error {
+	ret := _mock.Called(rdmaDev, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetRdmaDevName")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(rdmaDev, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockManager_SetRdmaDevName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRdmaDevName'
+type MockManager_SetRdmaDevName_Call struct {
+	*mock.Call
+}
+
+// SetRdmaDevName is a helper method to define mock.On call
+//   - rdmaDev string
+//   - name string
+func (_e *MockManager_Expecter) SetRdmaDevName(rdmaDev interface{}, name interface{}) *MockManager_SetRdmaDevName_Call {
+	return &MockManager_SetRdmaDevName_Call{Call: _e.mock.On("SetRdmaDevName", rdmaDev, name)}
+}
+
+func (_c *MockManager_SetRdmaDevName_Call) Run(run func(rdmaDev string, name string)) *MockManager_SetRdmaDevName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockManager_SetRdmaDevName_Call) Return(err error) *MockManager_SetRdmaDevName_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockManager_SetRdmaDevName_Call) RunAndReturn(run func(rdmaDev string, name string) error) *MockManager_SetRdmaDevName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetSystemRdmaMode provides a mock function for the type MockManager
 func (_mock *MockManager) SetSystemRdmaMode(mode string) error {
 	ret := _mock.Called(mode)

--- a/pkg/rdma/rdma.go
+++ b/pkg/rdma/rdma.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -27,6 +28,8 @@ type Manager interface {
 	GetSystemRdmaMode() (string, error)
 	// Set RDMA subsystem namespace awareness mode ["exclusive" | "shared"]
 	SetSystemRdmaMode(mode string) error
+	// Set RDMA device name
+	SetRdmaDevName(rdmaDev string, name string) error
 }
 
 type rdmaManagerNetlink struct {
@@ -65,4 +68,24 @@ func (rmn *rdmaManagerNetlink) GetSystemRdmaMode() (string, error) {
 // Set RDMA subsystem namespace awareness mode ["exclusive" | "shared"]
 func (rmn *rdmaManagerNetlink) SetSystemRdmaMode(mode string) error {
 	return rmn.rdmaOps.RdmaSystemSetNetnsMode(mode)
+}
+
+// Set RDMA device name
+func (rmn *rdmaManagerNetlink) SetRdmaDevName(rdmaDev string, name string) error {
+	log.Info().Msgf("setting RDMA device %s name to %s", rdmaDev, name)
+	// check if the RDMA device name is already set
+	rdmaLink, err := rmn.rdmaOps.RdmaLinkByName(name)
+	if err != nil {
+		return fmt.Errorf("cannot find RDMA link from name: %s", rdmaDev)
+	}
+	// if the RDMA device name is already set, do nothing and return nil
+	if rdmaLink.Attrs.Name == name {
+		return nil
+	}
+	// fetch the RDMA link from given by device id
+	rdmaLink, err = rmn.rdmaOps.RdmaLinkByName(rdmaDev)
+	if err != nil {
+		return fmt.Errorf("cannot find RDMA link from name: %s", rdmaDev)
+	}
+	return rmn.rdmaOps.RdmaLinkSetName(rdmaLink, name)
 }

--- a/pkg/rdma/rdma_ops.go
+++ b/pkg/rdma/rdma_ops.go
@@ -19,6 +19,8 @@ type BasicOps interface {
 	GetRdmaDevicesForPcidev(pcidevName string) []string
 	// Equivalent to rdmamap.GetRdmaDevicesForAuxdev(...)
 	GetRdmaDevicesForAuxdev(auxDev string) []string
+	// Equivalent to netlink.RdmaLinkSetName(...)
+	RdmaLinkSetName(link *netlink.RdmaLink, name string) error
 }
 
 func newRdmaBasicOps() BasicOps {
@@ -56,4 +58,9 @@ func (rdma *rdmaBasicOpsImpl) GetRdmaDevicesForPcidev(pcidevName string) []strin
 // Equivalent to rdmamap.GetRdmaDevicesForAuxdev(...)
 func (rdma *rdmaBasicOpsImpl) GetRdmaDevicesForAuxdev(auxDev string) []string {
 	return rdmamap.GetRdmaDevicesForAuxdev(auxDev)
+}
+
+// Equivalent to netlink.RdmaLinkSetName(...)
+func (rdma *rdmaBasicOpsImpl) RdmaLinkSetName(link *netlink.RdmaLink, name string) error {
+	return netlink.RdmaLinkSetName(link, name)
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -16,7 +16,8 @@ type CNIArgs struct {
 
 type RdmaCNIArgs struct {
 	types.CommonArgs
-	Debug bool `json:"debug"` // Run CNI in debug mode
+	RDMADeviceName string `json:"rdmaDeviceName,omitempty"` // user can specify a custom RDMA device name through the CNI args
+	Debug          bool   `json:"debug"`                    // Run CNI in debug mode
 }
 
 // RDMA Network state struct version


### PR DESCRIPTION
Adding 'rdmaDeviceName' in CNI arg, for user to set customized RDMA device name.
There are certain use-cases when user would like to persist RDMA device name that is associated to pod (container) namespace.
**Example:**
User would like to use custom name RDMA device `rdma_r1`
```
apiVersion: v1
kind: Pod
metadata:
  name: sriov-rdma-client
  namespace: default
  labels:
    app: sriov-rdma
    role: client
  annotations:
    k8s.v1.cni.cncf.io/networks: |
      [
        {
          "name": "rdma-sriov-network",
          "cni-args": {
            "rdmaDeviceName": "rdma_r1"
          }
        }
      ]
...
```
**Inside Pod:**
```
root@sriov-rdma-client:/# ls -l /sys/class/infiniband/
lrwxrwxrwx 1 root root 0 Mar 17 15:07 rdma_r1 -> ../../devices/pci0000:00/0000:00:02.7/0000:08:00.7/infiniband/rdma_r1
```
