### PR TITLE
Setting custom RDMA device names

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ Set default RoCE **TOS** (Type of Service) and **TC** (traffic class) for the RD
 
 > __*Note:*__ `"args"` is optional. `"rdmaQoS"` is optional; include `tos` and/or `tc` as needed for your fabric QoS.
 
+### RDMADeviceName (optional)
+Optional `rdmaDeviceName` (under `args.cni`) allow users to set custom RDMA device name. Upon `cmdDel` original RDMA device name will be restored.
+
+```json
+{
+  "cniVersion": "0.3.1",
+  "type": "rdma",
+  "args": {
+    "cni": {
+      "rdmaDeviceName": "custom-name",
+      "debug": true
+    }
+  }
+}
+```
+> __*Note:*__ `rdmaDeviceName` is optional
+
 # Deployment
 
 ## System configuration

--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -56,6 +56,11 @@ var (
 	date    = "unknown date"
 )
 
+const (
+	// prefix for RDMA device names in container namespace
+	rdmaDevPrefix = "rdma_"
+)
+
 type NsManager interface {
 	GetNS(string) (ns.NetNS, error)
 	GetCurrentNS() (ns.NetNS, error)
@@ -180,8 +185,11 @@ func (plugin *rdmaCniPlugin) moveRdmaDevFromNs(rdmaDev, nsPath string) error {
 
 func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	log.Info().Msgf("RDMA-CNI: cmdAdd")
-	var err error
-	var conf *rdmatypes.RdmaNetConf
+	var (
+		err         error
+		conf        *rdmatypes.RdmaNetConf
+		origRdmaDev string
+	)
 	conf, err = plugin.parseConf(args.StdinData, args.Args)
 	if err != nil {
 		return err
@@ -220,23 +228,30 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	// Move RDMA device to container namespace
-	rdmaDev, err := plugin.getRDMADevice(conf.DeviceID)
+	// Get RDMA device name from netdevice or CNI args
+	rdmaDev, origRdmaDev, err := plugin.getRDMADevice(result, conf.Args.CNI, conf.DeviceID)
 	if err != nil {
 		return fmt.Errorf("failed to get RDMA device for device ID %s: %w", conf.DeviceID, err)
 	}
 	// fetch RDMA device QoS from RDMA-CNI QoS configuration or read from RDMA device sysfs
-	hostQos, qos, err := plugin.getRdmaDevQoS(conf.RDMAQoS, rdmaDev)
+	hostQos, qos, err := plugin.getRdmaDevQoS(conf.RDMAQoS, origRdmaDev)
 	if err != nil {
 		return fmt.Errorf("failed to get RDMA device %s QoS: %w", rdmaDev, err)
 	}
 
 	// set RDMA device traffic class in root namespace, since mlx5_ib driver does not support setting TC in netns
-	err = plugin.qosManager.SetRdmaDevQoS(nil, rdmaDev, rdmatypes.RDMAQoS{TOS: 0, TC: qos.TC})
+	err = plugin.qosManager.SetRdmaDevQoS(nil, origRdmaDev, rdmatypes.RDMAQoS{TOS: 0, TC: qos.TC})
 	if err != nil {
 		return fmt.Errorf("failed to set RDMA device %s QoS: %+v. %v", rdmaDev, rdmatypes.RDMAQoS{TOS: 0, TC: qos.TC}, err)
 	}
+	log.Debug().Msgf("rdmaDev: %s, origRdmaDev: %s", rdmaDev, origRdmaDev)
 
+	// Modify custom RDMA device name through the CNI args
+	err = plugin.setRdmaDevName(origRdmaDev, rdmaDev)
+	if err != nil {
+		return fmt.Errorf("failed to set RDMA device %s name: %w", rdmaDev, err)
+	}
+	// Move RDMA device to container namespace
 	err = plugin.moveRdmaDevToNs(rdmaDev, args.Netns)
 	if err != nil {
 		return fmt.Errorf("failed to move RDMA device %s to namespace. %v", rdmaDev, err)
@@ -247,9 +262,11 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to set RDMA device %s QoS. %v", rdmaDev, err)
 	}
 
+	// Save RDMA state
 	state := rdmatypes.NewRdmaNetState()
 	state.DeviceID = conf.DeviceID
-	state.SandboxRdmaDevName = rdmaDev
+	state.SandboxRdmaDevName = origRdmaDev
+	// upon deletion restore RDMA device name to its original name
 	state.ContainerRdmaDevName = rdmaDev
 	// restore host QoS upon deletion
 	state.RDMAQoS = hostQos
@@ -300,6 +317,8 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 	}
 
 	// Move RDMA device to default namespace
+	// upon RDMA device restore, the RDMA device name will be set to its original name
+	// revoking custom RDMA device name applied in container network namespace.
 	err = plugin.moveRdmaDevFromNs(rdmaState.ContainerRdmaDevName, args.Netns)
 	if err != nil {
 		return fmt.Errorf(
@@ -312,6 +331,12 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 	}
 	log.Info().Msgf("RDMA device %s QoS: %+v", rdmaState.ContainerRdmaDevName, rdmaState.RDMAQoS)
 
+	// Restore root namespace RDMA device name stored in cache
+	err = plugin.setRdmaDevName(rdmaState.ContainerRdmaDevName, rdmaState.SandboxRdmaDevName)
+	if err != nil {
+		return fmt.Errorf("failed to set RDMA device %s name: %w", rdmaState.ContainerRdmaDevName, err)
+	}
+
 	err = plugin.stateCache.Delete(pRef)
 	if err != nil {
 		log.Warn().Msgf("failed to delete cache entry(%q). %v", pRef, err)
@@ -319,28 +344,58 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 	return nil
 }
 
-// getRDMADevice returns the first RDMA device found for the given deviceID.
-func (plugin *rdmaCniPlugin) getRDMADevice(deviceID string) (string, error) {
-	var rdmaDevs []string
+// getRDMADevice returns CNI interface name or user provided name as the RDMA device name.
+// Original RDMA device name is returned to restore the RDMA device name upon CmdDel.
+func (plugin *rdmaCniPlugin) getRDMADevice(prev *current.Result,
+	args rdmatypes.RdmaCNIArgs, deviceID string) (string, string, error) {
+	var (
+		rdmaDevs    []string
+		origRdmaDev string
+	)
+
 	if utils.IsPCIAddress(deviceID) {
 		rdmaDevs = plugin.rdmaManager.GetRdmaDevsForPciDev(deviceID)
 		if len(rdmaDevs) == 0 {
-			return "", errors.New("no RDMA devices found")
+			return "", "", errors.New("no RDMA devices found")
 		}
 	} else {
 		rdmaDevs = plugin.rdmaManager.GetRdmaDevsForAuxDev(deviceID)
 		if len(rdmaDevs) == 0 {
-			return "", errors.New("no RDMA devices found")
+			return "", "", errors.New("no RDMA devices found")
 		}
 	}
 
 	if len(rdmaDevs) != 1 {
 		// Expecting exactly one RDMA device
-		return "", fmt.Errorf(
+		return "", "", fmt.Errorf(
 			"discovered more than one RDMA device %v. Unsupported state", rdmaDevs)
 	}
+	// original RDMA device name is the first RDMA device found
+	origRdmaDev = rdmaDevs[0]
 
-	return rdmaDevs[0], nil
+	// use CNI interface name or user provided name as the RDMA device name
+	if prev != nil && len(prev.Interfaces) > 0 && prev.Interfaces[0].Name != "" {
+		rdmaDevs[0] = rdmaDevPrefix + prev.Interfaces[0].Name
+	}
+	if args.RDMADeviceName != "" {
+		rdmaDevs[0] = args.RDMADeviceName
+	}
+
+	return rdmaDevs[0], origRdmaDev, nil
+}
+
+// setRdmaDevName sets the RDMA device name according to rdmaDevPrefix + netdevice
+// or user defined RDMA device name provided in the CNI args.
+func (plugin *rdmaCniPlugin) setRdmaDevName(origRdmaDev, rdmaDev string) error {
+	if origRdmaDev == rdmaDev {
+		// do nothing
+		return nil
+	}
+	err := plugin.rdmaManager.SetRdmaDevName(origRdmaDev, rdmaDev)
+	if err != nil {
+		return fmt.Errorf("failed to set RDMA device %s name to %s: %w", origRdmaDev, rdmaDev, err)
+	}
+	return nil
 }
 
 // setRdmaDevQoS sets the RDMA device QoS in the given network namespace

--- a/cmd/rdma/main_test.go
+++ b/cmd/rdma/main_test.go
@@ -52,7 +52,7 @@ func generateNetConfCmdDel(netName string, qos rdmaTypes.RDMAQoS) rdmaTypes.Rdma
 	}
 }
 
-func generateNetConfCmdAdd(netName, cIfname, deviceID string, qos rdmaTypes.RDMAQoS) rdmaTypes.RdmaNetConf {
+func generateNetConfCmdAdd(netName, cIfname, deviceID string, rdmaDevName string, qos rdmaTypes.RDMAQoS) rdmaTypes.RdmaNetConf {
 	prevResult := current.Result{
 		CNIVersion: "0.4.0",
 		Interfaces: []*current.Interface{{
@@ -81,6 +81,7 @@ func generateNetConfCmdAdd(netName, cIfname, deviceID string, qos rdmaTypes.RDMA
 		},
 		DeviceID: deviceID,
 		RDMAQoS:  qos,
+		Args:     rdmaTypes.CNIArgs{CNI: rdmaTypes.RdmaCNIArgs{RDMADeviceName: rdmaDevName}},
 	}
 }
 
@@ -246,24 +247,26 @@ var _ = Describe("Main", func() {
 			It("Should succeed and move Rdma device associated with provided PCI DeviceID to Namespace", func() {
 				pciDev := "0000:04:00.5"
 				netName := "rdma-net"
-				rdmaDev := "mlx5_4"
 				cIfname := "net1"
+				rdmaDev := rdmaDevPrefix + cIfname
+				origRdmaDev := "mlx5_4"
 				cid := "a1b2c3d4e5f6"
 				qos := rdmaTypes.RDMAQoS{TOS: 96, TC: 26}
 				hostQos := rdmaTypes.RDMAQoS{TOS: 0, TC: 0}
 				cnsPath := "/proc/12444/ns/net"
 				cns, _ := dummyNsMgr.GetNS(cnsPath)
-				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev, qos)
+				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev, "", qos)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
 				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
-				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{rdmaDev}, nil)
+				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{origRdmaDev}, nil)
+				rdmaMgrMock.On("SetRdmaDevName", origRdmaDev, rdmaDev).Return(nil)
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
 				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
-				rdmaQoSManagerMock.On("GetRdmaDevQoS", rdmaDev).Return(hostQos, qos, nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, rdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
+				rdmaQoSManagerMock.On("GetRdmaDevQoS", origRdmaDev).Return(hostQos, qos, nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
 				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
-				expectedState := generateRdmaNetState(pciDev, rdmaDev, rdmaDev, hostQos)
+				expectedState := generateRdmaNetState(pciDev, origRdmaDev, rdmaDev, hostQos)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
 				err := plugin.CmdAdd(&args)
 				Expect(err).ToNot(HaveOccurred())
@@ -273,24 +276,55 @@ var _ = Describe("Main", func() {
 			It("Should succeed and move Rdma device associated with auxiliary device DeviceID to Namespace", func() {
 				auxDev := "mlx5_core.sf.6"
 				netName := "rdma-net"
-				rdmaDev := "mlx5_6"
 				cIfname := "net2"
+				rdmaDev := rdmaDevPrefix + cIfname
+				origRdmaDev := "mlx5_6"
 				cid := "a6b5c4d3e2f1"
 				qos := rdmaTypes.RDMAQoS{TOS: 102, TC: 10}
 				hostQos := rdmaTypes.RDMAQoS{TOS: 51, TC: 5}
 				cnsPath := "/proc/11142/ns/net"
 				cns, _ := dummyNsMgr.GetNS(cnsPath)
-				netconf := generateNetConfCmdAdd(netName, cIfname, auxDev, qos)
+				netconf := generateNetConfCmdAdd(netName, cIfname, auxDev, "", qos)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
 				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
-				rdmaMgrMock.On("GetRdmaDevsForAuxDev", auxDev).Return([]string{rdmaDev}, nil)
+				rdmaMgrMock.On("GetRdmaDevsForAuxDev", auxDev).Return([]string{origRdmaDev}, nil)
+				rdmaMgrMock.On("SetRdmaDevName", origRdmaDev, rdmaDev).Return(nil)
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
 				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
-				rdmaQoSManagerMock.On("GetRdmaDevQoS", rdmaDev).Return(hostQos, qos, nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, rdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
+				rdmaQoSManagerMock.On("GetRdmaDevQoS", origRdmaDev).Return(hostQos, qos, nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
 				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
-				expectedState := generateRdmaNetState(auxDev, rdmaDev, rdmaDev, hostQos)
+				expectedState := generateRdmaNetState(auxDev, origRdmaDev, rdmaDev, hostQos)
+				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
+				err := plugin.CmdAdd(&args)
+				Expect(err).ToNot(HaveOccurred())
+				rdmaMgrMock.AssertExpectations(t)
+				stateCacheMock.AssertExpectations(t)
+			})
+			It("Should succeed and move Rdma device associated with provided PCI DeviceID to Namespace with custom RDMA device name", func() {
+				pciDev := "0000:04:00.5"
+				netName := "rdma-net"
+				cIfname := "net1"
+				rdmaDev := rdmaDevPrefix + cIfname
+				origRdmaDev := "mlx5_4"
+				customRdmaDev := "custom-rdma"
+				qos := rdmaTypes.RDMAQoS{TOS: 96, TC: 26}
+				cid := "a1b2c3d4e5f6"
+				cnsPath := "/proc/12444/ns/net"
+				cns, _ := dummyNsMgr.GetNS(cnsPath)
+				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev, customRdmaDev, qos)
+				args := generateArgs(cnsPath, cid, cIfname, &netconf)
+				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
+				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{origRdmaDev}, nil)
+				rdmaMgrMock.On("SetRdmaDevName", origRdmaDev, customRdmaDev).Return(nil)
+				rdmaDev = netconf.Args.CNI.RDMADeviceName
+				rdmaQoSManagerMock.On("GetRdmaDevQoS", rdmaDev).Return(rdmaTypes.RDMAQoS{TOS: 0, TC: 0}, qos, nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, rdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
+				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
+				expectedState := generateRdmaNetState(pciDev, origRdmaDev, rdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: 0})
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
 				err := plugin.CmdAdd(&args)
 				Expect(err).ToNot(HaveOccurred())
@@ -308,22 +342,24 @@ var _ = Describe("Main", func() {
 				netName := "rdma-net"
 				rdmaDev := "mlx5_4"
 				cIfname := "net1"
+				containerRdmaDev := rdmaDevPrefix + cIfname
 				cid := "a1b2c3d4e5f6"
 				cnsPath := "/proc/12444/ns/net"
 				cns, _ := dummyNsMgr.GetCurrentNS()
 				qos := rdmaTypes.RDMAQoS{TOS: 96, TC: 33}
-				rdmaState := generateRdmaNetState(pciDev, rdmaDev, rdmaDev, qos)
+				rdmaState := generateRdmaNetState(pciDev, rdmaDev, containerRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: 0})
 				netconf := generateNetConfCmdDel(netName, qos)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
 				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, rdmaDev, qos).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, containerRdmaDev, rdmaState.RDMAQoS).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
 				stateCacheMock.On("Load", mock.AnythingOfType("cache.StateRef"),
 					mock.AnythingOfType("*types.RdmaNetState")).Return(nil).Run(func(args mock.Arguments) {
 					arg := args.Get(1).(*rdmaTypes.RdmaNetState)
 					*arg = rdmaState
 				})
-				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
+				rdmaMgrMock.On("MoveRdmaDevToNs", containerRdmaDev, cns).Return(nil)
+				rdmaMgrMock.On("SetRdmaDevName", containerRdmaDev, rdmaDev).Return(nil)
 				stateCacheMock.On("Delete", mock.AnythingOfType("cache.StateRef")).Return(nil)
 				err := plugin.CmdDel(&args)
 				Expect(err).ToNot(HaveOccurred())
@@ -335,22 +371,24 @@ var _ = Describe("Main", func() {
 				netName := "rdma-net"
 				rdmaDev := "mlx5_6"
 				cIfname := "net2"
+				containerRdmaDev := rdmaDevPrefix + cIfname
 				cid := "a1b2c3d4e5f6"
 				qos := rdmaTypes.RDMAQoS{TOS: 102, TC: 55}
 				cnsPath := "/proc/12444/ns/net"
 				cns, _ := dummyNsMgr.GetCurrentNS()
-				rdmaState := generateRdmaNetState(auxDev, rdmaDev, rdmaDev, qos)
+				rdmaState := generateRdmaNetState(auxDev, rdmaDev, containerRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: 0})
 				netconf := generateNetConfCmdDel(netName, qos)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
 				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, rdmaDev, qos).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, containerRdmaDev, rdmaState.RDMAQoS).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
 				stateCacheMock.On("Load", mock.AnythingOfType("cache.StateRef"),
 					mock.AnythingOfType("*types.RdmaNetState")).Return(nil).Run(func(args mock.Arguments) {
 					arg := args.Get(1).(*rdmaTypes.RdmaNetState)
 					*arg = rdmaState
 				})
-				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
+				rdmaMgrMock.On("MoveRdmaDevToNs", containerRdmaDev, cns).Return(nil)
+				rdmaMgrMock.On("SetRdmaDevName", containerRdmaDev, rdmaDev).Return(nil)
 				stateCacheMock.On("Delete", mock.AnythingOfType("cache.StateRef")).Return(nil)
 				err := plugin.CmdDel(&args)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/rdma/mocks/RdmaBasicOps.go
+++ b/pkg/rdma/mocks/RdmaBasicOps.go
@@ -204,6 +204,63 @@ func (_c *MockBasicOps_RdmaLinkByName_Call) RunAndReturn(run func(name string) (
 	return _c
 }
 
+// RdmaLinkSetName provides a mock function for the type MockBasicOps
+func (_mock *MockBasicOps) RdmaLinkSetName(link *netlink.RdmaLink, name string) error {
+	ret := _mock.Called(link, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RdmaLinkSetName")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*netlink.RdmaLink, string) error); ok {
+		r0 = returnFunc(link, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBasicOps_RdmaLinkSetName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RdmaLinkSetName'
+type MockBasicOps_RdmaLinkSetName_Call struct {
+	*mock.Call
+}
+
+// RdmaLinkSetName is a helper method to define mock.On call
+//   - link *netlink.RdmaLink
+//   - name string
+func (_e *MockBasicOps_Expecter) RdmaLinkSetName(link interface{}, name interface{}) *MockBasicOps_RdmaLinkSetName_Call {
+	return &MockBasicOps_RdmaLinkSetName_Call{Call: _e.mock.On("RdmaLinkSetName", link, name)}
+}
+
+func (_c *MockBasicOps_RdmaLinkSetName_Call) Run(run func(link *netlink.RdmaLink, name string)) *MockBasicOps_RdmaLinkSetName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *netlink.RdmaLink
+		if args[0] != nil {
+			arg0 = args[0].(*netlink.RdmaLink)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBasicOps_RdmaLinkSetName_Call) Return(err error) *MockBasicOps_RdmaLinkSetName_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBasicOps_RdmaLinkSetName_Call) RunAndReturn(run func(link *netlink.RdmaLink, name string) error) *MockBasicOps_RdmaLinkSetName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RdmaLinkSetNsFd provides a mock function for the type MockBasicOps
 func (_mock *MockBasicOps) RdmaLinkSetNsFd(link *netlink.RdmaLink, fd uint32) error {
 	ret := _mock.Called(link, fd)

--- a/pkg/rdma/mocks/RdmaManager.go
+++ b/pkg/rdma/mocks/RdmaManager.go
@@ -252,6 +252,63 @@ func (_c *MockManager_MoveRdmaDevToNs_Call) RunAndReturn(run func(rdmaDev string
 	return _c
 }
 
+// SetRdmaDevName provides a mock function for the type MockManager
+func (_mock *MockManager) SetRdmaDevName(rdmaDev string, name string) error {
+	ret := _mock.Called(rdmaDev, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetRdmaDevName")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(rdmaDev, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockManager_SetRdmaDevName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRdmaDevName'
+type MockManager_SetRdmaDevName_Call struct {
+	*mock.Call
+}
+
+// SetRdmaDevName is a helper method to define mock.On call
+//   - rdmaDev string
+//   - name string
+func (_e *MockManager_Expecter) SetRdmaDevName(rdmaDev interface{}, name interface{}) *MockManager_SetRdmaDevName_Call {
+	return &MockManager_SetRdmaDevName_Call{Call: _e.mock.On("SetRdmaDevName", rdmaDev, name)}
+}
+
+func (_c *MockManager_SetRdmaDevName_Call) Run(run func(rdmaDev string, name string)) *MockManager_SetRdmaDevName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockManager_SetRdmaDevName_Call) Return(err error) *MockManager_SetRdmaDevName_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockManager_SetRdmaDevName_Call) RunAndReturn(run func(rdmaDev string, name string) error) *MockManager_SetRdmaDevName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetSystemRdmaMode provides a mock function for the type MockManager
 func (_mock *MockManager) SetSystemRdmaMode(mode string) error {
 	ret := _mock.Called(mode)

--- a/pkg/rdma/rdma.go
+++ b/pkg/rdma/rdma.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -43,6 +44,8 @@ type Manager interface {
 	GetSystemRdmaMode() (string, error)
 	// Set RDMA subsystem namespace awareness mode ["exclusive" | "shared"]
 	SetSystemRdmaMode(mode string) error
+	// Set RDMA device name
+	SetRdmaDevName(rdmaDev string, name string) error
 }
 
 type rdmaManagerNetlink struct {
@@ -81,4 +84,22 @@ func (rmn *rdmaManagerNetlink) GetSystemRdmaMode() (string, error) {
 // Set RDMA subsystem namespace awareness mode ["exclusive" | "shared"]
 func (rmn *rdmaManagerNetlink) SetSystemRdmaMode(mode string) error {
 	return rmn.rdmaOps.RdmaSystemSetNetnsMode(mode)
+}
+
+// Set RDMA device name
+func (rmn *rdmaManagerNetlink) SetRdmaDevName(rdmaDev string, name string) error {
+	log.Info().Msgf("setting RDMA device %s name to %s", rdmaDev, name)
+	// check if the RDMA device name is already set
+	rdmaLink, _ := rmn.rdmaOps.RdmaLinkByName(name)
+	// if the RDMA device name is already set, do nothing and return nil
+	if rdmaLink != nil && rdmaLink.Attrs.Name == name {
+		log.Info().Msgf("RDMA device %s name already exists", name)
+		return nil
+	}
+	// fetch the RDMA link from given by device id
+	rdmaLink, err := rmn.rdmaOps.RdmaLinkByName(rdmaDev)
+	if err != nil {
+		return fmt.Errorf("cannot find RDMA link from name: %s", rdmaDev)
+	}
+	return rmn.rdmaOps.RdmaLinkSetName(rdmaLink, name)
 }

--- a/pkg/rdma/rdma_ops.go
+++ b/pkg/rdma/rdma_ops.go
@@ -35,6 +35,8 @@ type BasicOps interface {
 	GetRdmaDevicesForPcidev(pcidevName string) []string
 	// Equivalent to rdmamap.GetRdmaDevicesForAuxdev(...)
 	GetRdmaDevicesForAuxdev(auxDev string) []string
+	// Equivalent to netlink.RdmaLinkSetName(...)
+	RdmaLinkSetName(link *netlink.RdmaLink, name string) error
 }
 
 func newRdmaBasicOps() BasicOps {
@@ -72,4 +74,9 @@ func (rdma *rdmaBasicOpsImpl) GetRdmaDevicesForPcidev(pcidevName string) []strin
 // Equivalent to rdmamap.GetRdmaDevicesForAuxdev(...)
 func (rdma *rdmaBasicOpsImpl) GetRdmaDevicesForAuxdev(auxDev string) []string {
 	return rdmamap.GetRdmaDevicesForAuxdev(auxDev)
+}
+
+// Equivalent to netlink.RdmaLinkSetName(...)
+func (rdma *rdmaBasicOpsImpl) RdmaLinkSetName(link *netlink.RdmaLink, name string) error {
+	return netlink.RdmaLinkSetName(link, name)
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,7 +33,8 @@ type CNIArgs struct {
 
 type RdmaCNIArgs struct {
 	types.CommonArgs
-	Debug bool `json:"debug"` // Run CNI in debug mode
+	RDMADeviceName string `json:"rdmaDeviceName,omitempty"` // user can specify a custom RDMA device name through the CNI args
+	Debug          bool   `json:"debug"`                    // Run CNI in debug mode
 }
 type RDMAQoS struct {
 	TOS uint32 `json:"tos"` // RoCE TOS (Type of Service) value to set for the RDMA device


### PR DESCRIPTION
RDMA device name will be derived from applied in CNI conf interface[0] name (`rdma_`+netdevice name).
Adding `rdmaDeviceName` in CNI arg, for user to set customized RDMA device name. In case user adds `rdmaDeviceName` it will override any other RDMA device name (e.g. netdevice name or root namespace device name).
There are certain use-cases when user would like to persist RDMA device name. Adding `rdmaDeviceName` in cni-args.

Upon `CmdDel` host RDMA device name will be restored (e.g. mlx5_<n>)

**Example**
```
apiVersion: v1
kind: Pod
metadata:
  name: sriov-rdma-client
  namespace: default
  labels:
    app: sriov-rdma
    role: client
  annotations:
    k8s.v1.cni.cncf.io/networks: |
      [
        {
          "name": "rdma-sriov-network",
          "cni-args": {
            "rdmaDeviceName": "rdma_r1"
          }
        }
      ]
...
```
**Verifying Pod's RDMA Device Name**
```
ls -l /sys/class/infiniband/
lrwxrwxrwx 1 root root 0 Mar 17 15:07 rdma_r1 -> ../../devices/pci0000:00/0000:00:02.7/0000:08:00.7/infiniband/rdma_r1
```