### PR TITLE
fix: RDMA device consistent naming

### DIFF
--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -51,9 +51,10 @@ var (
 )
 
 var (
-	version = "master@git"
-	commit  = "unknown commit"
-	date    = "unknown date"
+	version               = "master@git"
+	commit                = "unknown commit"
+	date                  = "unknown date"
+	skipRdmaDeviceRestore = false
 )
 
 const (
@@ -180,7 +181,7 @@ func (plugin *rdmaCniPlugin) moveRdmaDevFromNs(rdmaDev, nsPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to move RDMA device %s to default namespace. %v", rdmaDev, err)
 	}
-	return err
+	return nil
 }
 
 func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
@@ -229,7 +230,7 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// Get RDMA device name from netdevice or CNI args
-	rdmaDev, origRdmaDev, err := plugin.getRDMADevice(result, conf.Args.CNI, conf.DeviceID)
+	rdmaDev, origRdmaDev, err := plugin.getRDMADevice(conf.Args.CNI.RDMADeviceName, args.IfName, conf.DeviceID)
 	if err != nil {
 		return fmt.Errorf("failed to get RDMA device for device ID %s: %w", conf.DeviceID, err)
 	}
@@ -319,22 +320,36 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 	// Move RDMA device to default namespace
 	// upon RDMA device restore, the RDMA device name will be set to its original name
 	// revoking custom RDMA device name applied in container network namespace.
-	err = plugin.moveRdmaDevFromNs(rdmaState.ContainerRdmaDevName, args.Netns)
+	rdmaDev := rdmaState.ContainerRdmaDevName
+	err = plugin.moveRdmaDevFromNs(rdmaDev, args.Netns)
 	if err != nil {
-		return fmt.Errorf(
-			"failed to restore RDMA device %s to default namespace. %v", rdmaState.ContainerRdmaDevName, err)
+		// if RDMA device is not found in container namespace, device was probably removed by a preceding cni CMD_DEL call
+		if errors.Is(err, rdma.ErrRdmaDeviceNotFound) {
+			log.Warn().Msgf("RDMA device %s not found in default namespace. %v", rdmaDev, err)
+			rdmaDev = rdmaState.SandboxRdmaDevName
+			skipRdmaDeviceRestore = true
+		} else {
+			return fmt.Errorf(
+				"failed to restore RDMA device %s to default namespace. %v", rdmaDev, err)
+		}
 	}
 	// restore RDMA device QoS once the RDMA device is restored to the default namespace
-	err = plugin.qosManager.SetRdmaDevQoS(nil, rdmaState.ContainerRdmaDevName, rdmaState.RDMAQoS)
+	err = plugin.qosManager.SetRdmaDevQoS(nil, rdmaDev, rdmaState.RDMAQoS)
 	if err != nil {
-		return fmt.Errorf("failed to set RDMA device %s QoS: %+v. %v", rdmaState.ContainerRdmaDevName, rdmaState.RDMAQoS, err)
+		if errors.Is(err, rdma.ErrRdmaDeviceNotFound) {
+			log.Warn().Msgf("RDMA device %s not found. Restoring QoS failed. %v", rdmaDev, err)
+			return nil
+		}
+		return fmt.Errorf("failed to set RDMA device %s QoS: %+v. %v", rdmaDev, rdmaState.RDMAQoS, err)
 	}
-	log.Info().Msgf("RDMA device %s QoS: %+v", rdmaState.ContainerRdmaDevName, rdmaState.RDMAQoS)
+	log.Info().Msgf("RDMA device %s QoS: %+v", rdmaDev, rdmaState.RDMAQoS)
 
-	// Restore root namespace RDMA device name stored in cache
-	err = plugin.setRdmaDevName(rdmaState.ContainerRdmaDevName, rdmaState.SandboxRdmaDevName)
-	if err != nil {
-		return fmt.Errorf("failed to set RDMA device %s name: %w", rdmaState.ContainerRdmaDevName, err)
+	if !skipRdmaDeviceRestore {
+		// Restore root namespace RDMA device name stored in cache
+		err = plugin.setRdmaDevName(rdmaState.ContainerRdmaDevName, rdmaState.SandboxRdmaDevName)
+		if err != nil {
+			return fmt.Errorf("failed to set RDMA device %s name: %w", rdmaState.ContainerRdmaDevName, err)
+		}
 	}
 
 	err = plugin.stateCache.Delete(pRef)
@@ -346,8 +361,8 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 
 // getRDMADevice returns CNI interface name or user provided name as the RDMA device name.
 // Original RDMA device name is returned to restore the RDMA device name upon CmdDel.
-func (plugin *rdmaCniPlugin) getRDMADevice(prev *current.Result,
-	args rdmatypes.RdmaCNIArgs, deviceID string) (string, string, error) {
+func (plugin *rdmaCniPlugin) getRDMADevice(rdmaDeviceName,
+	ifName, deviceID string) (string, string, error) {
 	var (
 		rdmaDevs    []string
 		origRdmaDev string
@@ -374,11 +389,11 @@ func (plugin *rdmaCniPlugin) getRDMADevice(prev *current.Result,
 	origRdmaDev = rdmaDevs[0]
 
 	// use CNI interface name or user provided name as the RDMA device name
-	if prev != nil && len(prev.Interfaces) > 0 && prev.Interfaces[0].Name != "" {
-		rdmaDevs[0] = rdmaDevPrefix + prev.Interfaces[0].Name
+	if ifName != "" {
+		rdmaDevs[0] = rdmaDevPrefix + ifName
 	}
-	if args.RDMADeviceName != "" {
-		rdmaDevs[0] = args.RDMADeviceName
+	if rdmaDeviceName != "" {
+		rdmaDevs[0] = rdmaDeviceName
 	}
 
 	return rdmaDevs[0], origRdmaDev, nil
@@ -393,6 +408,10 @@ func (plugin *rdmaCniPlugin) setRdmaDevName(origRdmaDev, rdmaDev string) error {
 	}
 	err := plugin.rdmaManager.SetRdmaDevName(origRdmaDev, rdmaDev)
 	if err != nil {
+		if errors.Is(err, rdma.ErrRdmaDeviceNotFound) {
+			log.Warn().Msgf("RDMA device %s not found. %v", origRdmaDev, err)
+			return nil
+		}
 		return fmt.Errorf("failed to set RDMA device %s name to %s: %w", origRdmaDev, rdmaDev, err)
 	}
 	return nil

--- a/pkg/rdma/rdma.go
+++ b/pkg/rdma/rdma.go
@@ -17,6 +17,7 @@
 package rdma
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -26,6 +27,10 @@ import (
 const (
 	RdmaSysModeExclusive = "exclusive"
 	RdmaSysModeShared    = "shared"
+)
+
+var (
+	ErrRdmaDeviceNotFound = errors.New("RDMA device not found")
 )
 
 func NewRdmaManager() Manager {
@@ -56,7 +61,7 @@ type rdmaManagerNetlink struct {
 func (rmn *rdmaManagerNetlink) MoveRdmaDevToNs(rdmaDev string, netNs ns.NetNS) error {
 	rdmaLink, err := rmn.rdmaOps.RdmaLinkByName(rdmaDev)
 	if err != nil {
-		return fmt.Errorf("cannot find RDMA link from name: %s", rdmaDev)
+		return fmt.Errorf("cannot find RDMA link from name: %s: %w", rdmaDev, ErrRdmaDeviceNotFound)
 	}
 	err = rmn.rdmaOps.RdmaLinkSetNsFd(rdmaLink, uint32(netNs.Fd()))
 	if err != nil {
@@ -99,7 +104,7 @@ func (rmn *rdmaManagerNetlink) SetRdmaDevName(rdmaDev string, name string) error
 	// fetch the RDMA link from given by device id
 	rdmaLink, err := rmn.rdmaOps.RdmaLinkByName(rdmaDev)
 	if err != nil {
-		return fmt.Errorf("cannot find RDMA link from name: %s", rdmaDev)
+		return fmt.Errorf("cannot find RDMA link from name: %s. %w", rdmaDev, ErrRdmaDeviceNotFound)
 	}
 	return rmn.rdmaOps.RdmaLinkSetName(rdmaLink, name)
 }

--- a/pkg/rdma/rdma_qos.go
+++ b/pkg/rdma/rdma_qos.go
@@ -18,11 +18,13 @@ package rdma
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	rdmatypes "github.com/k8snetworkplumbingwg/rdma-cni/pkg/types"
@@ -145,7 +147,10 @@ func (rqm *rdmaQoSManagerOpsIml) setRdmaDevQoSToSysfs(targetNs ns.NetNS, rdmaDev
 	}
 	err = os.WriteFile(path.Join(rdmaDevQoSPath, "ports", "1", "default_roce_tos"), []byte(strconv.Itoa(int(qos.TOS))), 0644)
 	if err != nil {
-		return err
+		if errors.Is(err, syscall.ENODEV) {
+			return fmt.Errorf("rdma device %s not found while writing default_roce_tos: %w",
+				rdmaDev, errors.Join(ErrRdmaDeviceNotFound, err))
+		}
 	}
 
 	// check if /sys/class/infiniband/<rdmaDev>/tc exists


### PR DESCRIPTION
**Fix consistent naming**
Using CNI args IfName instead of prev conf. Since rdma device name is derived by applied container network interface. 

**Fix stuck CmdDel command** 
In case of missing RDMA device in container namespace, don't fail rather than skip RDMA device restore, which was done by preceding chained CNI CMD_DEL call 
