### PR TITLE
fix: keep root ns default rdma device name in case QoS is no set

### DIFF
--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -230,7 +230,7 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// Get RDMA device name from netdevice or CNI args
-	rdmaDev, origRdmaDev, err := plugin.getRDMADevice(conf.Args.CNI.RDMADeviceName, args.IfName, conf.DeviceID)
+	rdmaDev, origRdmaDev, err := plugin.getRDMADevice(conf, args.IfName)
 	if err != nil {
 		return fmt.Errorf("failed to get RDMA device for device ID %s: %w", conf.DeviceID, err)
 	}
@@ -240,12 +240,14 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to get RDMA device %s QoS: %w", rdmaDev, err)
 	}
 
-	// set RDMA device traffic class in root namespace, since mlx5_ib driver does not support setting TC in netns
-	err = plugin.qosManager.SetRdmaDevQoS(nil, origRdmaDev, rdmatypes.RDMAQoS{TOS: 0, TC: qos.TC})
-	if err != nil {
-		return fmt.Errorf("failed to set RDMA device %s QoS: %+v. %v", rdmaDev, rdmatypes.RDMAQoS{TOS: 0, TC: qos.TC}, err)
+	// set RDMA device traffic class in root namespace, since mlx5_ib driver does not support setting TC in netns.
+	if qos != nil {
+		err = plugin.qosManager.SetRdmaDevQoS(nil, origRdmaDev, &rdmatypes.RDMAQoS{TOS: 0, TC: qos.TC})
+		if err != nil {
+			return fmt.Errorf("failed to set RDMA device %s QoS: %+v. %v", rdmaDev, rdmatypes.RDMAQoS{TOS: 0, TC: qos.TC}, err)
+		}
+		log.Debug().Msgf("rdmaDev: %s, origRdmaDev: %s", rdmaDev, origRdmaDev)
 	}
-	log.Debug().Msgf("rdmaDev: %s, origRdmaDev: %s", rdmaDev, origRdmaDev)
 
 	// Modify custom RDMA device name through the CNI args
 	err = plugin.setRdmaDevName(origRdmaDev, rdmaDev)
@@ -257,10 +259,12 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return fmt.Errorf("failed to move RDMA device %s to namespace. %v", rdmaDev, err)
 	}
-	// set RDMA device TOS in container namespace
-	err = plugin.setRdmaDevQoS(args.Netns, rdmaDev, rdmatypes.RDMAQoS{TOS: qos.TOS, TC: 0})
-	if err != nil {
-		return fmt.Errorf("failed to set RDMA device %s QoS. %v", rdmaDev, err)
+	if qos != nil {
+		// set RDMA device TOS in container namespace
+		err = plugin.setRdmaDevQoS(args.Netns, rdmaDev, &rdmatypes.RDMAQoS{TOS: qos.TOS, TC: 0})
+		if err != nil {
+			return fmt.Errorf("failed to set RDMA device %s QoS. %v", rdmaDev, err)
+		}
 	}
 
 	// Save RDMA state
@@ -334,15 +338,17 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 		}
 	}
 	// restore RDMA device QoS once the RDMA device is restored to the default namespace
-	err = plugin.qosManager.SetRdmaDevQoS(nil, rdmaDev, rdmaState.RDMAQoS)
-	if err != nil {
-		if errors.Is(err, rdma.ErrRdmaDeviceNotFound) {
-			log.Warn().Msgf("RDMA device %s not found. Restoring QoS failed. %v", rdmaDev, err)
-			return nil
+	if rdmaState.RDMAQoS != nil {
+		err = plugin.qosManager.SetRdmaDevQoS(nil, rdmaDev, rdmaState.RDMAQoS)
+		if err != nil {
+			if errors.Is(err, rdma.ErrRdmaDeviceNotFound) {
+				log.Warn().Msgf("RDMA device %s not found. Restoring QoS failed. %v", rdmaDev, err)
+				return nil
+			}
+			return fmt.Errorf("failed to set RDMA device %s QoS: %+v. %v", rdmaDev, rdmaState.RDMAQoS, err)
 		}
-		return fmt.Errorf("failed to set RDMA device %s QoS: %+v. %v", rdmaDev, rdmaState.RDMAQoS, err)
+		log.Info().Msgf("RDMA device %s QoS: %+v", rdmaDev, rdmaState.RDMAQoS)
 	}
-	log.Info().Msgf("RDMA device %s QoS: %+v", rdmaDev, rdmaState.RDMAQoS)
 
 	if !skipRdmaDeviceRestore {
 		// Restore root namespace RDMA device name stored in cache
@@ -361,13 +367,14 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 
 // getRDMADevice returns CNI interface name or user provided name as the RDMA device name.
 // Original RDMA device name is returned to restore the RDMA device name upon CmdDel.
-func (plugin *rdmaCniPlugin) getRDMADevice(rdmaDeviceName,
-	ifName, deviceID string) (string, string, error) {
+func (plugin *rdmaCniPlugin) getRDMADevice(rdmaConf *rdmatypes.RdmaNetConf,
+	ifName string) (string, string, error) {
 	var (
 		rdmaDevs    []string
 		origRdmaDev string
 	)
 
+	deviceID := rdmaConf.DeviceID
 	if utils.IsPCIAddress(deviceID) {
 		rdmaDevs = plugin.rdmaManager.GetRdmaDevsForPciDev(deviceID)
 		if len(rdmaDevs) == 0 {
@@ -389,11 +396,15 @@ func (plugin *rdmaCniPlugin) getRDMADevice(rdmaDeviceName,
 	origRdmaDev = rdmaDevs[0]
 
 	// use CNI interface name or user provided name as the RDMA device name
-	if ifName != "" {
+	// todo: since there is a kernel bug which prevents using same rdma device name in host,
+	// even on different netns although exlusive mode is set.
+	// customization of rdma device name is conditioned:
+	// setting 'rdma_' prefix + ifName only in case of QoS is set and ifName is provided
+	if rdmaConf.RDMAQoS != nil && ifName != "" {
 		rdmaDevs[0] = rdmaDevPrefix + ifName
 	}
-	if rdmaDeviceName != "" {
-		rdmaDevs[0] = rdmaDeviceName
+	if rdmaConf.Args.CNI.RDMADeviceName != "" {
+		rdmaDevs[0] = rdmaConf.Args.CNI.RDMADeviceName
 	}
 
 	return rdmaDevs[0], origRdmaDev, nil
@@ -418,7 +429,7 @@ func (plugin *rdmaCniPlugin) setRdmaDevName(origRdmaDev, rdmaDev string) error {
 }
 
 // setRdmaDevQoS sets the RDMA device QoS in the given network namespace
-func (plugin *rdmaCniPlugin) setRdmaDevQoS(netns string, rdmaDev string, qos rdmatypes.RDMAQoS) error {
+func (plugin *rdmaCniPlugin) setRdmaDevQoS(netns string, rdmaDev string, qos *rdmatypes.RDMAQoS) error {
 	log.Info().Msgf("targetNS: %s, rdmaDev: %s, qos: %+v", netns, rdmaDev, qos)
 	targetNs, err := plugin.nsManager.GetNS(netns)
 	if err != nil {
@@ -435,13 +446,13 @@ func (plugin *rdmaCniPlugin) setRdmaDevQoS(netns string, rdmaDev string, qos rdm
 	return err
 }
 
-func (plugin *rdmaCniPlugin) getRdmaDevQoS(confQos rdmatypes.RDMAQoS, rdmaDev string) (rdmatypes.RDMAQoS, rdmatypes.RDMAQoS, error) {
+func (plugin *rdmaCniPlugin) getRdmaDevQoS(confQos *rdmatypes.RDMAQoS, rdmaDev string) (*rdmatypes.RDMAQoS, *rdmatypes.RDMAQoS, error) {
 	// Load RDMA CNI QoS configuration
 	plugin.qosManager.LoadRdmaCniQoSConfig(confQos)
 	// Get RDMA device QoS
 	hostQos, qos, err := plugin.qosManager.GetRdmaDevQoS(rdmaDev)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, rdmatypes.RDMAQoS{}, fmt.Errorf("failed to get RDMA device %s QoS: %w", rdmaDev, err)
+		return nil, nil, fmt.Errorf("failed to get RDMA device %s QoS: %w", rdmaDev, err)
 	}
 	log.Info().Msgf("RDMA device %s QoS: %+v", rdmaDev, qos)
 	return hostQos, qos, nil

--- a/cmd/rdma/main_test.go
+++ b/cmd/rdma/main_test.go
@@ -35,7 +35,7 @@ import (
 	rdmaTypes "github.com/k8snetworkplumbingwg/rdma-cni/pkg/types"
 )
 
-func generateNetConfCmdDel(netName string, qos rdmaTypes.RDMAQoS) rdmaTypes.RdmaNetConf {
+func generateNetConfCmdDel(netName string, qos *rdmaTypes.RDMAQoS) rdmaTypes.RdmaNetConf {
 	return rdmaTypes.RdmaNetConf{
 		NetConf: types.NetConf{
 			CNIVersion:    "0.4.0",
@@ -52,7 +52,7 @@ func generateNetConfCmdDel(netName string, qos rdmaTypes.RDMAQoS) rdmaTypes.Rdma
 	}
 }
 
-func generateNetConfCmdAdd(netName, cIfname, deviceID string, rdmaDevName string, qos rdmaTypes.RDMAQoS) rdmaTypes.RdmaNetConf {
+func generateNetConfCmdAdd(netName, cIfname, deviceID string, rdmaDevName string, qos *rdmaTypes.RDMAQoS) rdmaTypes.RdmaNetConf {
 	prevResult := current.Result{
 		CNIVersion: "0.4.0",
 		Interfaces: []*current.Interface{{
@@ -81,7 +81,7 @@ func generateNetConfCmdAdd(netName, cIfname, deviceID string, rdmaDevName string
 		},
 		DeviceID: deviceID,
 		RDMAQoS:  qos,
-		Args:     rdmaTypes.CNIArgs{CNI: rdmaTypes.RdmaCNIArgs{RDMADeviceName: rdmaDevName}},
+		Args:     rdmaTypes.CNIArgs{CNI: rdmaTypes.RdmaCNIArgs{Debug: true, RDMADeviceName: rdmaDevName}},
 	}
 }
 
@@ -97,7 +97,7 @@ func generateArgs(nsPath, cid, cIfname string, netconf *rdmaTypes.RdmaNetConf) s
 	}
 }
 
-func generateRdmaNetState(deviceID, sanboxRdmaDev, containerRdmaDev string, qos rdmaTypes.RDMAQoS) rdmaTypes.RdmaNetState {
+func generateRdmaNetState(deviceID, sanboxRdmaDev, containerRdmaDev string, qos *rdmaTypes.RDMAQoS) rdmaTypes.RdmaNetState {
 	state := rdmaTypes.NewRdmaNetState()
 	state.DeviceID = deviceID
 	state.SandboxRdmaDevName = sanboxRdmaDev
@@ -244,15 +244,38 @@ var _ = Describe("Main", func() {
 
 	Describe("Test CmdAdd()", func() {
 		Context("Valid configuration provided", func() {
-			It("Should succeed and move Rdma device associated with provided PCI DeviceID to Namespace", func() {
+			It("Should succeed and move Rdma device associated with provided PCI DeviceID to Namespace without QoS", func() {
+				pciDev := "0000:04:00.5"
+				netName := "rdma-net"
+				cIfname := "net1"
+				origRdmaDev := "mlx5_1"
+				cid := "a1b2c3d4e5f6"
+				cnsPath := "/proc/12444/ns/net"
+				cns, _ := dummyNsMgr.GetNS(cnsPath)
+				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev, "", nil)
+				args := generateArgs(cnsPath, cid, cIfname, &netconf)
+				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
+				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{origRdmaDev}, nil)
+				rdmaMgrMock.On("MoveRdmaDevToNs", origRdmaDev, cns).Return(nil)
+				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", (*rdmaTypes.RDMAQoS)(nil)).Return(nil)
+				rdmaQoSManagerMock.On("GetRdmaDevQoS", origRdmaDev).Return(nil, nil, nil)
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
+				expectedState := generateRdmaNetState(pciDev, origRdmaDev, origRdmaDev, nil)
+				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
+				err := plugin.CmdAdd(&args)
+				Expect(err).ToNot(HaveOccurred())
+				rdmaMgrMock.AssertExpectations(t)
+				stateCacheMock.AssertExpectations(t)
+			})
+			It("Should succeed and move Rdma device associated with provided PCI DeviceID to Namespace with QoS", func() {
 				pciDev := "0000:04:00.5"
 				netName := "rdma-net"
 				cIfname := "net1"
 				rdmaDev := rdmaDevPrefix + cIfname
-				origRdmaDev := "mlx5_4"
+				origRdmaDev := "mlx5_2"
 				cid := "a1b2c3d4e5f6"
-				qos := rdmaTypes.RDMAQoS{TOS: 96, TC: 26}
-				hostQos := rdmaTypes.RDMAQoS{TOS: 0, TC: 0}
+				qos := &rdmaTypes.RDMAQoS{TOS: 96, TC: 26}
+				hostQos := &rdmaTypes.RDMAQoS{TOS: 0, TC: 0}
 				cnsPath := "/proc/12444/ns/net"
 				cns, _ := dummyNsMgr.GetNS(cnsPath)
 				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev, "", qos)
@@ -263,8 +286,8 @@ var _ = Describe("Main", func() {
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
 				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
 				rdmaQoSManagerMock.On("GetRdmaDevQoS", origRdmaDev).Return(hostQos, qos, nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, &rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, &rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
 				expectedState := generateRdmaNetState(pciDev, origRdmaDev, rdmaDev, hostQos)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
@@ -273,15 +296,15 @@ var _ = Describe("Main", func() {
 				rdmaMgrMock.AssertExpectations(t)
 				stateCacheMock.AssertExpectations(t)
 			})
-			It("Should succeed and move Rdma device associated with auxiliary device DeviceID to Namespace", func() {
+			It("Should succeed and move Rdma device associated with auxiliary device DeviceID to Namespace with QoS", func() {
 				auxDev := "mlx5_core.sf.6"
 				netName := "rdma-net"
 				cIfname := "net2"
 				rdmaDev := rdmaDevPrefix + cIfname
-				origRdmaDev := "mlx5_6"
+				origRdmaDev := "mlx5_3"
 				cid := "a6b5c4d3e2f1"
-				qos := rdmaTypes.RDMAQoS{TOS: 102, TC: 10}
-				hostQos := rdmaTypes.RDMAQoS{TOS: 51, TC: 5}
+				qos := &rdmaTypes.RDMAQoS{TOS: 102, TC: 10}
+				hostQos := &rdmaTypes.RDMAQoS{TOS: 51, TC: 5}
 				cnsPath := "/proc/11142/ns/net"
 				cns, _ := dummyNsMgr.GetNS(cnsPath)
 				netconf := generateNetConfCmdAdd(netName, cIfname, auxDev, "", qos)
@@ -292,8 +315,8 @@ var _ = Describe("Main", func() {
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
 				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
 				rdmaQoSManagerMock.On("GetRdmaDevQoS", origRdmaDev).Return(hostQos, qos, nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, &rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, &rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
 				expectedState := generateRdmaNetState(auxDev, origRdmaDev, rdmaDev, hostQos)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
@@ -302,16 +325,17 @@ var _ = Describe("Main", func() {
 				rdmaMgrMock.AssertExpectations(t)
 				stateCacheMock.AssertExpectations(t)
 			})
-			It("Should succeed and move Rdma device associated with provided PCI DeviceID to Namespace with custom RDMA device name", func() {
-				pciDev := "0000:04:00.5"
+			It("Should succeed and move Rdma device associated with provided PCI DeviceID to Namespace with custom RDMA device name and QoS", func() {
+				pciDev := "0000:04:00.6"
 				netName := "rdma-net"
 				cIfname := "net1"
 				rdmaDev := rdmaDevPrefix + cIfname
 				origRdmaDev := "mlx5_4"
 				customRdmaDev := "custom-rdma"
-				qos := rdmaTypes.RDMAQoS{TOS: 96, TC: 26}
-				cid := "a1b2c3d4e5f6"
-				cnsPath := "/proc/12444/ns/net"
+				qos := &rdmaTypes.RDMAQoS{TOS: 96, TC: 26}
+				hostQos := &rdmaTypes.RDMAQoS{TOS: 51, TC: 5}
+				cid := "a1b2c3d4e5f7"
+				cnsPath := "/proc/12445/ns/net"
 				cns, _ := dummyNsMgr.GetNS(cnsPath)
 				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev, customRdmaDev, qos)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
@@ -319,12 +343,12 @@ var _ = Describe("Main", func() {
 				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{origRdmaDev}, nil)
 				rdmaMgrMock.On("SetRdmaDevName", origRdmaDev, customRdmaDev).Return(nil)
 				rdmaDev = netconf.Args.CNI.RDMADeviceName
-				rdmaQoSManagerMock.On("GetRdmaDevQoS", rdmaDev).Return(rdmaTypes.RDMAQoS{TOS: 0, TC: 0}, qos, nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, rdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
+				rdmaQoSManagerMock.On("GetRdmaDevQoS", origRdmaDev).Return(hostQos, qos, nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, &rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, &rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
-				expectedState := generateRdmaNetState(pciDev, origRdmaDev, rdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: 0})
+				expectedState := generateRdmaNetState(pciDev, origRdmaDev, rdmaDev, hostQos)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
 				err := plugin.CmdAdd(&args)
 				Expect(err).ToNot(HaveOccurred())
@@ -337,7 +361,31 @@ var _ = Describe("Main", func() {
 
 	Describe("Test CmdDel()", func() {
 		Context("Valid configuration provided", func() {
-			It("Should succeed and move Rdma device associated with PCI net device back to sandbox namespace", func() {
+			It("Should succeed and move Rdma device associated with PCI net device back to sandbox namespace without QoS", func() {
+				pciDev := "0000:04:00.5"
+				netName := "rdma-net"
+				rdmaDev := "mlx5_1"
+				cIfname := "net1"
+				cid := "a1b2c3d4e5f6"
+				cnsPath := "/proc/12444/ns/net"
+				cns, _ := dummyNsMgr.GetCurrentNS()
+				rdmaState := generateRdmaNetState(pciDev, rdmaDev, rdmaDev, nil)
+				netconf := generateNetConfCmdDel(netName, nil)
+				args := generateArgs(cnsPath, cid, cIfname, &netconf)
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
+				stateCacheMock.On("Load", mock.AnythingOfType("cache.StateRef"),
+					mock.AnythingOfType("*types.RdmaNetState")).Return(nil).Run(func(args mock.Arguments) {
+					arg := args.Get(1).(*rdmaTypes.RdmaNetState)
+					*arg = rdmaState
+				})
+				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
+				stateCacheMock.On("Delete", mock.AnythingOfType("cache.StateRef")).Return(nil)
+				err := plugin.CmdDel(&args)
+				Expect(err).ToNot(HaveOccurred())
+				rdmaMgrMock.AssertExpectations(t)
+				stateCacheMock.AssertExpectations(t)
+			})
+			It("Should succeed and move Rdma device associated with PCI net device back to sandbox namespace with QoS", func() {
 				pciDev := "0000:04:00.5"
 				netName := "rdma-net"
 				rdmaDev := "mlx5_4"
@@ -346,11 +394,10 @@ var _ = Describe("Main", func() {
 				cid := "a1b2c3d4e5f6"
 				cnsPath := "/proc/12444/ns/net"
 				cns, _ := dummyNsMgr.GetCurrentNS()
-				qos := rdmaTypes.RDMAQoS{TOS: 96, TC: 33}
-				rdmaState := generateRdmaNetState(pciDev, rdmaDev, containerRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: 0})
+				qos := &rdmaTypes.RDMAQoS{TOS: 96, TC: 33}
+				rdmaState := generateRdmaNetState(pciDev, rdmaDev, containerRdmaDev, &rdmaTypes.RDMAQoS{TOS: 0, TC: 0})
 				netconf := generateNetConfCmdDel(netName, qos)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
-				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
 				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, containerRdmaDev, rdmaState.RDMAQoS).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
 				stateCacheMock.On("Load", mock.AnythingOfType("cache.StateRef"),
@@ -366,20 +413,19 @@ var _ = Describe("Main", func() {
 				rdmaMgrMock.AssertExpectations(t)
 				stateCacheMock.AssertExpectations(t)
 			})
-			It("Should succeed and move Rdma device associated with auxiliary device back to sandbox namespace", func() {
+			It("Should succeed and move Rdma device associated with auxiliary device back to sandbox namespace with QoS", func() {
 				auxDev := "mlx5_core.sf.6"
 				netName := "rdma-net"
-				rdmaDev := "mlx5_6"
+				rdmaDev := "mlx5_3"
 				cIfname := "net2"
 				containerRdmaDev := rdmaDevPrefix + cIfname
 				cid := "a1b2c3d4e5f6"
-				qos := rdmaTypes.RDMAQoS{TOS: 102, TC: 55}
+				qos := &rdmaTypes.RDMAQoS{TOS: 102, TC: 55}
 				cnsPath := "/proc/12444/ns/net"
 				cns, _ := dummyNsMgr.GetCurrentNS()
-				rdmaState := generateRdmaNetState(auxDev, rdmaDev, containerRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: 0})
+				rdmaState := generateRdmaNetState(auxDev, rdmaDev, containerRdmaDev, &rdmaTypes.RDMAQoS{TOS: 0, TC: 0})
 				netconf := generateNetConfCmdDel(netName, qos)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
-				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
 				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, containerRdmaDev, rdmaState.RDMAQoS).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
 				stateCacheMock.On("Load", mock.AnythingOfType("cache.StateRef"),

--- a/pkg/rdma/mocks/RdmaQoS.go
+++ b/pkg/rdma/mocks/RdmaQoS.go
@@ -38,28 +38,32 @@ func (_m *MockQoSManager) EXPECT() *MockQoSManager_Expecter {
 }
 
 // GetRdmaDevQoS provides a mock function for the type MockQoSManager
-func (_mock *MockQoSManager) GetRdmaDevQoS(rdmaDev string) (types.RDMAQoS, types.RDMAQoS, error) {
+func (_mock *MockQoSManager) GetRdmaDevQoS(rdmaDev string) (*types.RDMAQoS, *types.RDMAQoS, error) {
 	ret := _mock.Called(rdmaDev)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRdmaDevQoS")
 	}
 
-	var r0 types.RDMAQoS
-	var r1 types.RDMAQoS
+	var r0 *types.RDMAQoS
+	var r1 *types.RDMAQoS
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(string) (types.RDMAQoS, types.RDMAQoS, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) (*types.RDMAQoS, *types.RDMAQoS, error)); ok {
 		return returnFunc(rdmaDev)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) types.RDMAQoS); ok {
+	if returnFunc, ok := ret.Get(0).(func(string) *types.RDMAQoS); ok {
 		r0 = returnFunc(rdmaDev)
 	} else {
-		r0 = ret.Get(0).(types.RDMAQoS)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.RDMAQoS)
+		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) types.RDMAQoS); ok {
+	if returnFunc, ok := ret.Get(1).(func(string) *types.RDMAQoS); ok {
 		r1 = returnFunc(rdmaDev)
 	} else {
-		r1 = ret.Get(1).(types.RDMAQoS)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*types.RDMAQoS)
+		}
 	}
 	if returnFunc, ok := ret.Get(2).(func(string) error); ok {
 		r2 = returnFunc(rdmaDev)
@@ -93,18 +97,18 @@ func (_c *MockQoSManager_GetRdmaDevQoS_Call) Run(run func(rdmaDev string)) *Mock
 	return _c
 }
 
-func (_c *MockQoSManager_GetRdmaDevQoS_Call) Return(rDMAQoS types.RDMAQoS, rDMAQoS1 types.RDMAQoS, err error) *MockQoSManager_GetRdmaDevQoS_Call {
+func (_c *MockQoSManager_GetRdmaDevQoS_Call) Return(rDMAQoS *types.RDMAQoS, rDMAQoS1 *types.RDMAQoS, err error) *MockQoSManager_GetRdmaDevQoS_Call {
 	_c.Call.Return(rDMAQoS, rDMAQoS1, err)
 	return _c
 }
 
-func (_c *MockQoSManager_GetRdmaDevQoS_Call) RunAndReturn(run func(rdmaDev string) (types.RDMAQoS, types.RDMAQoS, error)) *MockQoSManager_GetRdmaDevQoS_Call {
+func (_c *MockQoSManager_GetRdmaDevQoS_Call) RunAndReturn(run func(rdmaDev string) (*types.RDMAQoS, *types.RDMAQoS, error)) *MockQoSManager_GetRdmaDevQoS_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // LoadRdmaCniQoSConfig provides a mock function for the type MockQoSManager
-func (_mock *MockQoSManager) LoadRdmaCniQoSConfig(qosConf types.RDMAQoS) {
+func (_mock *MockQoSManager) LoadRdmaCniQoSConfig(qosConf *types.RDMAQoS) {
 	_mock.Called(qosConf)
 	return
 }
@@ -115,16 +119,16 @@ type MockQoSManager_LoadRdmaCniQoSConfig_Call struct {
 }
 
 // LoadRdmaCniQoSConfig is a helper method to define mock.On call
-//   - qosConf types.RDMAQoS
+//   - qosConf *types.RDMAQoS
 func (_e *MockQoSManager_Expecter) LoadRdmaCniQoSConfig(qosConf interface{}) *MockQoSManager_LoadRdmaCniQoSConfig_Call {
 	return &MockQoSManager_LoadRdmaCniQoSConfig_Call{Call: _e.mock.On("LoadRdmaCniQoSConfig", qosConf)}
 }
 
-func (_c *MockQoSManager_LoadRdmaCniQoSConfig_Call) Run(run func(qosConf types.RDMAQoS)) *MockQoSManager_LoadRdmaCniQoSConfig_Call {
+func (_c *MockQoSManager_LoadRdmaCniQoSConfig_Call) Run(run func(qosConf *types.RDMAQoS)) *MockQoSManager_LoadRdmaCniQoSConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 types.RDMAQoS
+		var arg0 *types.RDMAQoS
 		if args[0] != nil {
-			arg0 = args[0].(types.RDMAQoS)
+			arg0 = args[0].(*types.RDMAQoS)
 		}
 		run(
 			arg0,
@@ -138,13 +142,13 @@ func (_c *MockQoSManager_LoadRdmaCniQoSConfig_Call) Return() *MockQoSManager_Loa
 	return _c
 }
 
-func (_c *MockQoSManager_LoadRdmaCniQoSConfig_Call) RunAndReturn(run func(qosConf types.RDMAQoS)) *MockQoSManager_LoadRdmaCniQoSConfig_Call {
+func (_c *MockQoSManager_LoadRdmaCniQoSConfig_Call) RunAndReturn(run func(qosConf *types.RDMAQoS)) *MockQoSManager_LoadRdmaCniQoSConfig_Call {
 	_c.Run(run)
 	return _c
 }
 
 // SetRdmaDevQoS provides a mock function for the type MockQoSManager
-func (_mock *MockQoSManager) SetRdmaDevQoS(targetNs ns.NetNS, rdmaDev string, qos types.RDMAQoS) error {
+func (_mock *MockQoSManager) SetRdmaDevQoS(targetNs ns.NetNS, rdmaDev string, qos *types.RDMAQoS) error {
 	ret := _mock.Called(targetNs, rdmaDev, qos)
 
 	if len(ret) == 0 {
@@ -152,7 +156,7 @@ func (_mock *MockQoSManager) SetRdmaDevQoS(targetNs ns.NetNS, rdmaDev string, qo
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(ns.NetNS, string, types.RDMAQoS) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(ns.NetNS, string, *types.RDMAQoS) error); ok {
 		r0 = returnFunc(targetNs, rdmaDev, qos)
 	} else {
 		r0 = ret.Error(0)
@@ -168,12 +172,12 @@ type MockQoSManager_SetRdmaDevQoS_Call struct {
 // SetRdmaDevQoS is a helper method to define mock.On call
 //   - targetNs ns.NetNS
 //   - rdmaDev string
-//   - qos types.RDMAQoS
+//   - qos *types.RDMAQoS
 func (_e *MockQoSManager_Expecter) SetRdmaDevQoS(targetNs interface{}, rdmaDev interface{}, qos interface{}) *MockQoSManager_SetRdmaDevQoS_Call {
 	return &MockQoSManager_SetRdmaDevQoS_Call{Call: _e.mock.On("SetRdmaDevQoS", targetNs, rdmaDev, qos)}
 }
 
-func (_c *MockQoSManager_SetRdmaDevQoS_Call) Run(run func(targetNs ns.NetNS, rdmaDev string, qos types.RDMAQoS)) *MockQoSManager_SetRdmaDevQoS_Call {
+func (_c *MockQoSManager_SetRdmaDevQoS_Call) Run(run func(targetNs ns.NetNS, rdmaDev string, qos *types.RDMAQoS)) *MockQoSManager_SetRdmaDevQoS_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 ns.NetNS
 		if args[0] != nil {
@@ -183,9 +187,9 @@ func (_c *MockQoSManager_SetRdmaDevQoS_Call) Run(run func(targetNs ns.NetNS, rdm
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 types.RDMAQoS
+		var arg2 *types.RDMAQoS
 		if args[2] != nil {
-			arg2 = args[2].(types.RDMAQoS)
+			arg2 = args[2].(*types.RDMAQoS)
 		}
 		run(
 			arg0,
@@ -201,7 +205,7 @@ func (_c *MockQoSManager_SetRdmaDevQoS_Call) Return(err error) *MockQoSManager_S
 	return _c
 }
 
-func (_c *MockQoSManager_SetRdmaDevQoS_Call) RunAndReturn(run func(targetNs ns.NetNS, rdmaDev string, qos types.RDMAQoS) error) *MockQoSManager_SetRdmaDevQoS_Call {
+func (_c *MockQoSManager_SetRdmaDevQoS_Call) RunAndReturn(run func(targetNs ns.NetNS, rdmaDev string, qos *types.RDMAQoS) error) *MockQoSManager_SetRdmaDevQoS_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/rdma/rdma_qos.go
+++ b/pkg/rdma/rdma_qos.go
@@ -40,28 +40,28 @@ const (
 // QoSManager interface for managing RDMA device QoS configuration.
 type QoSManager interface {
 	// Get RDMA device QoS
-	GetRdmaDevQoS(rdmaDev string) (rdmatypes.RDMAQoS, rdmatypes.RDMAQoS, error)
+	GetRdmaDevQoS(rdmaDev string) (*rdmatypes.RDMAQoS, *rdmatypes.RDMAQoS, error)
 	// Set RDMA device QoS
-	SetRdmaDevQoS(targetNs ns.NetNS, rdmaDev string, qos rdmatypes.RDMAQoS) error
+	SetRdmaDevQoS(targetNs ns.NetNS, rdmaDev string, qos *rdmatypes.RDMAQoS) error
 	// Set RDMA CNI QoS configuration
-	LoadRdmaCniQoSConfig(qosConf rdmatypes.RDMAQoS)
+	LoadRdmaCniQoSConfig(qosConf *rdmatypes.RDMAQoS)
 }
 
 func NewRdmaQoSManager() QoSManager {
 	return &rdmaQoSManager{
-		qosConf: rdmatypes.RDMAQoS{},
+		qosConf: &rdmatypes.RDMAQoS{},
 		ops:     newrdmaQoSManagerOps(),
 	}
 }
 
 type rdmaQoSManager struct {
-	qosConf rdmatypes.RDMAQoS
+	qosConf *rdmatypes.RDMAQoS
 	ops     rdmaQoSManagerOps
 }
 
 type rdmaQoSManagerOps interface {
-	getRdmaDevQoSFormSysfs(rdmaDev string) (rdmatypes.RDMAQoS, error)
-	setRdmaDevQoSToSysfs(targetNs ns.NetNS, rdmaDev string, qos rdmatypes.RDMAQoS) error
+	getRdmaDevQoSFormSysfs(rdmaDev string) (*rdmatypes.RDMAQoS, error)
+	setRdmaDevQoSToSysfs(targetNs ns.NetNS, rdmaDev string, qos *rdmatypes.RDMAQoS) error
 }
 
 type rdmaQoSManagerOpsIml struct{}
@@ -74,7 +74,7 @@ func newrdmaQoSManagerOps() rdmaQoSManagerOps {
 // 1. create /sys/kernel/config/rdma_cm/<rdmaDev> directory
 // 2. read the default_roce_tos value from /sys/kernel/config/rdma_cm/<rdmaDev>/ports/1/default_roce_tos
 // 3. read the traffic class value from /sys/class/infiniband/<rdmaDev>/tc/1/traffic_class
-func (rqm *rdmaQoSManagerOpsIml) getRdmaDevQoSFormSysfs(rdmaDev string) (rdmatypes.RDMAQoS, error) {
+func (rqm *rdmaQoSManagerOpsIml) getRdmaDevQoSFormSysfs(rdmaDev string) (*rdmatypes.RDMAQoS, error) {
 	var (
 		tosVal uint32
 		tcVal  uint32
@@ -82,16 +82,16 @@ func (rqm *rdmaQoSManagerOpsIml) getRdmaDevQoSFormSysfs(rdmaDev string) (rdmatyp
 	rdmaDevQoSPath := path.Join(rdmaCMConfigfsPath, rdmaDev)
 	err := os.MkdirAll(rdmaDevQoSPath, 0755)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, fmt.Errorf("failed to create directory %s: %w", rdmaDevQoSPath, err)
+		return nil, fmt.Errorf("failed to create directory %s: %w", rdmaDevQoSPath, err)
 	}
 	tos, err := os.ReadFile(path.Join(rdmaDevQoSPath, "ports", "1", "default_roce_tos"))
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, err
+		return nil, err
 	}
 
 	tosVal, err = parseUint32(tos)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, err
+		return nil, err
 	}
 
 	// check if /sys/class/infiniband/<rdmaDev>/tc exists
@@ -100,7 +100,7 @@ func (rqm *rdmaQoSManagerOpsIml) getRdmaDevQoSFormSysfs(rdmaDev string) (rdmatyp
 		// file may contain multiple lines; first line is "Global tclass=<value>". If missing or invalid, use 0 so CNI config applies.
 		tc, err := os.ReadFile(path.Join(rdmaSysfsPath, rdmaDev, "tc", "1", "traffic_class"))
 		if err != nil {
-			return rdmatypes.RDMAQoS{}, fmt.Errorf("failed to read traffic class file for RDMA device %s: %w", rdmaDev, err)
+			return nil, fmt.Errorf("failed to read traffic class file for RDMA device %s: %w", rdmaDev, err)
 		}
 
 		// if tc is not empty, parse the traffic class value
@@ -112,17 +112,17 @@ func (rqm *rdmaQoSManagerOpsIml) getRdmaDevQoSFormSysfs(rdmaDev string) (rdmatyp
 			}
 			tcVal, err = parseUint32([]byte(tcValStr))
 			if err != nil {
-				return rdmatypes.RDMAQoS{}, err
+				return nil, err
 			}
 		}
 	} else {
 		if !os.IsNotExist(err) {
-			return rdmatypes.RDMAQoS{}, err
+			return nil, err
 		}
 		log.Warn().Msgf("TC (traffic class) was not found for RDMA device %s.", rdmaDev)
 	}
 
-	return rdmatypes.RDMAQoS{TOS: tosVal, TC: tcVal}, nil
+	return &rdmatypes.RDMAQoS{TOS: tosVal, TC: tcVal}, nil
 
 }
 
@@ -131,7 +131,7 @@ func (rqm *rdmaQoSManagerOpsIml) getRdmaDevQoSFormSysfs(rdmaDev string) (rdmatyp
 // to another netns via netlink.
 // CMA's cma_device is removed and re-created with zeroed default_roce_tos.
 // Setting QoS in the target namespace after the move is therefore required.
-func (rqm *rdmaQoSManagerOpsIml) setRdmaDevQoSToSysfs(targetNs ns.NetNS, rdmaDev string, qos rdmatypes.RDMAQoS) error {
+func (rqm *rdmaQoSManagerOpsIml) setRdmaDevQoSToSysfs(targetNs ns.NetNS, rdmaDev string, qos *rdmatypes.RDMAQoS) error {
 
 	// mount configfs in case executed in non-root network namespace
 	if targetNs != nil {
@@ -176,23 +176,26 @@ func (rqm *rdmaQoSManagerOpsIml) setRdmaDevQoSToSysfs(targetNs ns.NetNS, rdmaDev
 }
 
 // LoadRdmaCniQoSConfig sets RDMA CNI QoS configuration.
-func (rqm *rdmaQoSManager) LoadRdmaCniQoSConfig(qosConf rdmatypes.RDMAQoS) {
+func (rqm *rdmaQoSManager) LoadRdmaCniQoSConfig(qosConf *rdmatypes.RDMAQoS) {
 	rqm.qosConf = qosConf
 }
 
 // GetRdmaDevQoS gets RDMA device host QoS and CNI QoS configuration.
-func (rqm *rdmaQoSManager) GetRdmaDevQoS(rdmaDev string) (rdmatypes.RDMAQoS, rdmatypes.RDMAQoS, error) {
+func (rqm *rdmaQoSManager) GetRdmaDevQoS(rdmaDev string) (*rdmatypes.RDMAQoS, *rdmatypes.RDMAQoS, error) {
 	log.Info().Msgf("getting RDMA device %s QoS", rdmaDev)
 	hostQos, err := rqm.ops.getRdmaDevQoSFormSysfs(rdmaDev)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, rdmatypes.RDMAQoS{}, fmt.Errorf("failed to get RDMA device %s host QoS: %w", rdmaDev, err)
+		return nil, nil, fmt.Errorf("failed to get RDMA device %s host QoS: %w", rdmaDev, err)
 	}
 
 	return hostQos, rqm.qosConf, nil
 }
 
 // SetRdmaDevQoS sets RDMA device QoS.
-func (rqm *rdmaQoSManager) SetRdmaDevQoS(targetNs ns.NetNS, rdmaDev string, qos rdmatypes.RDMAQoS) error {
+func (rqm *rdmaQoSManager) SetRdmaDevQoS(targetNs ns.NetNS, rdmaDev string, qos *rdmatypes.RDMAQoS) error {
+	if qos == nil {
+		return nil
+	}
 	return rqm.ops.setRdmaDevQoSToSysfs(targetNs, rdmaDev, qos)
 }
 

--- a/pkg/rdma/rdma_qos_test.go
+++ b/pkg/rdma/rdma_qos_test.go
@@ -36,8 +36,8 @@ var _ = Describe("RdmaQoSManager", func() {
 
 	JustBeforeEach(func() {
 		qosManager = &rdmaQoSManager{
-			qosConf: rdmatypes.RDMAQoS{TOS: 99, TC: 11},
-			ops:     newFakerdmaQoSManagerOps(rdmatypes.RDMAQoS{TOS: 55, TC: 11}),
+			qosConf: &rdmatypes.RDMAQoS{TOS: 99, TC: 11},
+			ops:     newFakerdmaQoSManagerOps(&rdmatypes.RDMAQoS{TOS: 55, TC: 11}),
 		}
 	})
 
@@ -63,11 +63,11 @@ var _ = Describe("RdmaQoSManager", func() {
 	Describe("Test GetRdmaDevQoS()", func() {
 		Context("Basic Call, no failure from RdmaBasicOps", func() {
 			It("Should pass and return value as provided by rdmaBasicOps", func() {
-				retVal := rdmatypes.RDMAQoS{TOS: 99, TC: 11}
+				retVal := &rdmatypes.RDMAQoS{TOS: 99, TC: 11}
 				hostQos, qos, err := qosManager.GetRdmaDevQoS("mlx5_2")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(qos).To(Equal(retVal))
-				Expect(hostQos).To(Equal(rdmatypes.RDMAQoS{TOS: 55, TC: 11}))
+				Expect(hostQos).To(Equal(&rdmatypes.RDMAQoS{TOS: 55, TC: 11}))
 			})
 		})
 	})
@@ -75,7 +75,7 @@ var _ = Describe("RdmaQoSManager", func() {
 		Context("Basic Call, no failure from RdmaBasicOps", func() {
 			It("Should pass and return value as provided by rdmaBasicOps", func() {
 				netNs := &dummyNetNs{fd: 88}
-				err := qosManager.SetRdmaDevQoS(netNs, "mlx5_6", rdmatypes.RDMAQoS{TOS: 99, TC: 11})
+				err := qosManager.SetRdmaDevQoS(netNs, "mlx5_6", &rdmatypes.RDMAQoS{TOS: 99, TC: 11})
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -84,18 +84,18 @@ var _ = Describe("RdmaQoSManager", func() {
 
 type fakerdmaQoSManagerOps struct {
 	fakefs afero.Afero
-	qos    rdmatypes.RDMAQoS
+	qos    *rdmatypes.RDMAQoS
 }
 
-func newFakerdmaQoSManagerOps(qos rdmatypes.RDMAQoS) rdmaQoSManagerOps {
+func newFakerdmaQoSManagerOps(qos *rdmatypes.RDMAQoS) rdmaQoSManagerOps {
 	return &fakerdmaQoSManagerOps{fakefs: afero.Afero{Fs: afero.NewMemMapFs()}, qos: qos}
 }
 
-func (fqm *fakerdmaQoSManagerOps) getRdmaDevQoSFormSysfs(rdmaDev string) (rdmatypes.RDMAQoS, error) {
+func (fqm *fakerdmaQoSManagerOps) getRdmaDevQoSFormSysfs(rdmaDev string) (*rdmatypes.RDMAQoS, error) {
 	rdmaDevQoSPath := path.Join(rdmaCMConfigfsPath, rdmaDev, "ports", "1")
 	err := fqm.fakefs.MkdirAll(rdmaDevQoSPath, 0755)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, fmt.Errorf("failed to create directory %s: %w", rdmaDevQoSPath, err)
+		return nil, fmt.Errorf("failed to create directory %s: %w", rdmaDevQoSPath, err)
 	}
 
 	tosPath := path.Join(rdmaDevQoSPath, "default_roce_tos")
@@ -103,28 +103,28 @@ func (fqm *fakerdmaQoSManagerOps) getRdmaDevQoSFormSysfs(rdmaDev string) (rdmaty
 
 	tos, err := fqm.fakefs.ReadFile(tosPath)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, err
+		return nil, err
 	}
 	tosVal, err := parseUint32(tos)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, err
+		return nil, err
 	}
 	tcPath := path.Join(rdmaDevQoSPath, "tc", "1", "traffic_class")
 	fqm.fakefs.WriteFile(tcPath, []byte(strconv.Itoa(int(fqm.qos.TC))+"\n"), 0644)
 
 	tc, err := fqm.fakefs.ReadFile(tcPath)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, err
+		return nil, err
 	}
 	tcVal, err := parseUint32(tc)
 	if err != nil {
-		return rdmatypes.RDMAQoS{}, err
+		return nil, err
 	}
 
-	return rdmatypes.RDMAQoS{TOS: tosVal, TC: tcVal}, nil
+	return &rdmatypes.RDMAQoS{TOS: tosVal, TC: tcVal}, nil
 }
 
-func (fqm *fakerdmaQoSManagerOps) setRdmaDevQoSToSysfs(targetNs ns.NetNS, rdmaDev string, qos rdmatypes.RDMAQoS) error {
+func (fqm *fakerdmaQoSManagerOps) setRdmaDevQoSToSysfs(targetNs ns.NetNS, rdmaDev string, qos *rdmatypes.RDMAQoS) error {
 	rdmaDevQoSPath := path.Join(rdmaCMConfigfsPath, rdmaDev)
 	err := fqm.fakefs.MkdirAll(rdmaDevQoSPath, 0755)
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -22,9 +22,9 @@ import (
 
 type RdmaNetConf struct {
 	types.NetConf
-	DeviceID string  `json:"deviceID"`          // PCI address of a VF in valid sysfs format
-	RDMAQoS  RDMAQoS `json:"rdmaQoS,omitempty"` // RoCE QoS (Quality of Service) to set for the RDMA device
-	Args     CNIArgs `json:"args"`              // optional arguments passed to CNI as defined in CNI spec 0.2.0
+	DeviceID string   `json:"deviceID"`          // PCI address of a VF in valid sysfs format
+	RDMAQoS  *RDMAQoS `json:"rdmaQoS,omitempty"` // RoCE QoS (Quality of Service) to set for the RDMA device
+	Args     CNIArgs  `json:"args"`              // optional arguments passed to CNI as defined in CNI spec 0.2.0
 }
 
 type CNIArgs struct {
@@ -60,5 +60,5 @@ type RdmaNetState struct {
 	// RDMA device name in container
 	ContainerRdmaDevName string `json:"containerRdmaDevName"`
 	// RDMA device QoS
-	RDMAQoS RDMAQoS `json:"rdmaQoS,omitempty"`
+	RDMAQoS *RDMAQoS `json:"rdmaQoS,omitempty"`
 }


### PR DESCRIPTION
Since there is a kernel bug in rdma exclusive mode, preventing usage of same rdma device name.
under same host. Therefore rdma device persistent naming is coupled with RDMAQoS.

**Before Fix - Second pod fails to start**

```
kubectl get pods test-pod-c-237-175-20-024 -owide --no-headers
test-pod-c-237-175-20-024   0/1   ContainerCreating   0     3m32s   <none>   c-237-175-20-024   <none>   <none>

  Warning  FailedCreatePodSandBox  1s (x6 over 6s)  kubelet            (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "a628e373780969749140655cbd11ff3182ffc5bc12be48ca453144fd14ac8f0f": plugin type="multus" name="multus-cni-network" failed (add): [default/test-pod-c-237-175-20-024/8559430e-0acd-46a0-ae59-f3175115ad4b:sriov-network]: error adding container to network "sriov-network": plugin type="rdma" failed (add): failed to set RDMA device rdma_net1 name: failed to set RDMA device mlx5_6 name to rdma_net1: file exists
```
**After Fix - Second Pod Succeeds**

```
kubectl get pods test-pod-c-237-175-20-023 -owide --no-headers
test-pod-c-237-175-20-023   1/1   Running   0     3m58s   192.168.34.253   c-237-175-20-023   <none>   <none>
kubectl exec -it test-pod-c-237-175-20-023 -- bash
root@test-pod-c-237-175-20-023:/# ls -l /sys/class/infiniband
total 0
lrwxrwxrwx 1 root root 0 May 10 20:38 mlx5_2 -> ../../devices/pci0000:00/0000:00:02.7/0000:08:00.2/infiniband/mlx5_2
```
**Applying RDMAQoS**

```
apiVersion: sriovnetwork.openshift.io/v1
kind: SriovNetwork
metadata:
  name: sriov-network
spec:
  ipam: |
    {
      "type": "nv-ipam",
      "poolName": "nv-ipam-pool"
    }
  logLevel: info
  metaPlugins: |
    {
      "type": "rdma",
      "rdmaQoS": {
        "tos": 96,
        "tc": 102
      }
    }
kubectl get pods sriov-test-qcp9f -owide --no-headers
sriov-test-qcp9f   1/1   Running   0     38s   192.168.34.255   c-237-175-20-023   <none>   <none>
kubectl exec -it sriov-test-qcp9f -- bash
[root@sriov-test-qcp9f /]# ls -l /sys/class/infiniband
total 0
lrwxrwxrwx 1 root root 0 May 10 20:47 rdma_net1 -> ../../devices/pci0000:00/0000:00:02.7/0000:08:00.2/infiniband/rdma_net1
cat /sys/class/infiniband/rdma_net1/tc/1/traffic_class
Global tclass=102
Specifying rdmaDeviceName in workload as a workaround for rdma device name conflicts

kubectl get pods test-pod-c-237-175-20-023 -ojson | jq '.metadata.annotations["k8s.v1.cni.cncf.io/networks"]'
"[\n  {\n    \"name\": \"sriov-network\",\n    \"interface\": \"net_r1\",\n    \"cni-args\": {\n      \"rdmaDeviceName\": \"custom-name\"\n    }\n  }\n]\n"

kubectl get pods -o wide --field-selector spec.nodeName=c-237-175-20-023 --no-headers
sriov-test-qcp9f            1/1   Running   0     7m39s   192.168.34.255   c-237-175-20-023   <none>   <none>
test-pod-c-237-175-20-023   1/1   Running   0     2m59s   192.168.34.196   c-237-175-20-023   <none>   <none>


kubectl exec -it test-pod-c-237-175-20-023 -- bash
root@test-pod-c-237-175-20-023:/# ls -l /sys/class/infiniband
total 0
lrwxrwxrwx 1 root root 0 May 10 20:57 custom-name -> ../../devices/pci0000:00/0000:00:02.7/0000:08:00.3/infiniband/custom-name
cat /sys/class/infiniband/custom-name/tc/1/traffic_class
Global tclass=102
```
**Testing Restoration of rdma device name upon pod deletion**

```
kubectl get pods test-pod-c-237-175-20-023
Error from server (NotFound): pods "test-pod-c-237-175-20-023" not found

ls -l /sys/class/infiniband/ | grep "0000:08:00.3"
lrwxrwxrwx 1 root root 0 May 10 21:41 mlx5_3 -> ../../devices/pci0000:00/0000:00:02.7/0000:08:00.3/infiniband/mlx5_3
cat /sys/class/infiniband/mlx5_3/tc/1/traffic_class
Global tclass=0
```