### PR TITLE
fix: keep root netns rdma device name unless user specifies rdmaDeviceName

### DIFF
--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -230,7 +230,7 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// Get RDMA device name from netdevice or CNI args
-	rdmaDev, origRdmaDev, err := plugin.getRDMADevice(conf.Args.CNI.RDMADeviceName, args.IfName, conf.DeviceID)
+	rdmaDev, origRdmaDev, err := plugin.getRDMADevice(conf.Args.CNI.RDMADeviceName, conf.DeviceID)
 	if err != nil {
 		return fmt.Errorf("failed to get RDMA device for device ID %s: %w", conf.DeviceID, err)
 	}
@@ -361,8 +361,7 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 
 // getRDMADevice returns CNI interface name or user provided name as the RDMA device name.
 // Original RDMA device name is returned to restore the RDMA device name upon CmdDel.
-func (plugin *rdmaCniPlugin) getRDMADevice(rdmaDeviceName,
-	ifName, deviceID string) (string, string, error) {
+func (plugin *rdmaCniPlugin) getRDMADevice(rdmaDeviceName, deviceID string) (string, string, error) {
 	var (
 		rdmaDevs    []string
 		origRdmaDev string
@@ -388,10 +387,6 @@ func (plugin *rdmaCniPlugin) getRDMADevice(rdmaDeviceName,
 	// original RDMA device name is the first RDMA device found
 	origRdmaDev = rdmaDevs[0]
 
-	// use CNI interface name or user provided name as the RDMA device name
-	if ifName != "" {
-		rdmaDevs[0] = rdmaDevPrefix + ifName
-	}
 	if rdmaDeviceName != "" {
 		rdmaDevs[0] = rdmaDeviceName
 	}

--- a/cmd/rdma/main_test.go
+++ b/cmd/rdma/main_test.go
@@ -248,7 +248,6 @@ var _ = Describe("Main", func() {
 				pciDev := "0000:04:00.5"
 				netName := "rdma-net"
 				cIfname := "net1"
-				rdmaDev := rdmaDevPrefix + cIfname
 				origRdmaDev := "mlx5_4"
 				cid := "a1b2c3d4e5f6"
 				qos := rdmaTypes.RDMAQoS{TOS: 96, TC: 26}
@@ -259,14 +258,13 @@ var _ = Describe("Main", func() {
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
 				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
 				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{origRdmaDev}, nil)
-				rdmaMgrMock.On("SetRdmaDevName", origRdmaDev, rdmaDev).Return(nil)
-				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
+				rdmaMgrMock.On("MoveRdmaDevToNs", origRdmaDev, cns).Return(nil)
 				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
 				rdmaQoSManagerMock.On("GetRdmaDevQoS", origRdmaDev).Return(hostQos, qos, nil)
 				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, origRdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
-				expectedState := generateRdmaNetState(pciDev, origRdmaDev, rdmaDev, hostQos)
+				expectedState := generateRdmaNetState(pciDev, origRdmaDev, origRdmaDev, hostQos)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
 				err := plugin.CmdAdd(&args)
 				Expect(err).ToNot(HaveOccurred())
@@ -277,7 +275,6 @@ var _ = Describe("Main", func() {
 				auxDev := "mlx5_core.sf.6"
 				netName := "rdma-net"
 				cIfname := "net2"
-				rdmaDev := rdmaDevPrefix + cIfname
 				origRdmaDev := "mlx5_6"
 				cid := "a6b5c4d3e2f1"
 				qos := rdmaTypes.RDMAQoS{TOS: 102, TC: 10}
@@ -288,14 +285,13 @@ var _ = Describe("Main", func() {
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
 				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
 				rdmaMgrMock.On("GetRdmaDevsForAuxDev", auxDev).Return([]string{origRdmaDev}, nil)
-				rdmaMgrMock.On("SetRdmaDevName", origRdmaDev, rdmaDev).Return(nil)
-				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
+				rdmaMgrMock.On("MoveRdmaDevToNs", origRdmaDev, cns).Return(nil)
 				rdmaQoSManagerMock.On("LoadRdmaCniQoSConfig", qos).Return(nil)
 				rdmaQoSManagerMock.On("GetRdmaDevQoS", origRdmaDev).Return(hostQos, qos, nil)
 				rdmaQoSManagerMock.On("SetRdmaDevQoS", nil, origRdmaDev, rdmaTypes.RDMAQoS{TOS: 0, TC: qos.TC}).Return(nil)
-				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, rdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
+				rdmaQoSManagerMock.On("SetRdmaDevQoS", cns, origRdmaDev, rdmaTypes.RDMAQoS{TOS: qos.TOS, TC: 0}).Return(nil)
 				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
-				expectedState := generateRdmaNetState(auxDev, origRdmaDev, rdmaDev, hostQos)
+				expectedState := generateRdmaNetState(auxDev, origRdmaDev, origRdmaDev, hostQos)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
 				err := plugin.CmdAdd(&args)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
fix: since using same rdma device name under different netns is yet to be supported in kernel.
The fix is to override rdma device name only if user has defined 'rdmaDeviceName'

```
apiVersion: sriovnetwork.openshift.io/v1
kind: SriovNetwork
...
  metaPlugins: |
    {
      "type": "rdma",
      "rdmaQoS": {
        "tos": 96,
        "tc": 102
      },
      "args": {
        "cni": {
          "debug": true
        }
      }
    }

kubectl exec -it sriov-test-rk9v6 -- ls -l /sys/class/infiniband
total 0
lrwxrwxrwx 1 root root 0 May 11 13:13 mlx5_9 -> ../../devices/pci0000:00/0000:00:02.7/0000:08:01.1/infiniband/mlx5_9
```


```
apiVersion: sriovnetwork.openshift.io/v1
kind: SriovNetwork
...
  metaPlugins: |
    {
      "type": "rdma",
      "rdmaQoS": {
        "tos": 96,
        "tc": 102
      },      
      "args": {
        "cni": {
          "rdmaDeviceName": "foo-bar", 
          "debug": true
        }
      }
    }
kubectl exec -it sriov-test-r7mm7 -- ls -l /sys/class/infiniband
total 0
lrwxrwxrwx 1 root root 0 May 11 09:02 foo-bar -> ../../devices/pci0000:00/0000:00:02.7/0000:08:01.0/infiniband/foo-bar
```